### PR TITLE
chore: add aria-hidden to Icons

### DIFF
--- a/components/pages/home/FeaturedDiscount.vue
+++ b/components/pages/home/FeaturedDiscount.vue
@@ -32,7 +32,7 @@
       type="button"
       @click="closeBanner"
     >
-      <XMarkIcon class="h-6 w-6" />
+      <XMarkIcon aria-hidden="true" class="h-6 w-6" />
     </button>
 
     <h2 class="text-base-content-highlight text-xl leading-8 font-bold tracking-normal">Black Friday Sale! 🎉</h2>

--- a/components/pages/home/PageHistory.vue
+++ b/components/pages/home/PageHistory.vue
@@ -97,7 +97,7 @@
         type="button"
         @click="removeHistoryItem(historyItem.path)"
       >
-        <XMarkIcon class="h-5 w-5" />
+        <XMarkIcon aria-hidden="true" class="h-5 w-5" />
       </button>
     </li>
   </ol>

--- a/components/pages/home/SimpleSearch.vue
+++ b/components/pages/home/SimpleSearch.vue
@@ -76,7 +76,7 @@
       <div class="group relative">
         <!-- Icon -->
         <div class="group pointer-events-none absolute inset-y-0 left-0 flex items-center rounded-l-md px-2">
-          <MagnifyingGlassIcon class="h-5 w-5 text-base-content group-hover:text-base-content-hover" />
+          <MagnifyingGlassIcon aria-hidden="true" class="h-5 w-5 text-base-content group-hover:text-base-content-hover" />
         </div>
 
         <!-- Input -->
@@ -116,7 +116,7 @@
                 v-if="selected"
                 class="absolute inset-y-0 left-0 flex items-center pl-1.5 text-base-content-highlight"
               >
-                <CheckIcon class="h-5 w-5" />
+                <CheckIcon aria-hidden="true" class="h-5 w-5" />
               </span>
             </div>
           </HeadlessComboboxOption>
@@ -137,7 +137,7 @@
                 v-if="selected"
                 class="absolute inset-y-0 left-0 flex items-center pl-1.5 text-base-content-highlight"
               >
-                <CheckIcon class="h-5 w-5" />
+                <CheckIcon aria-hidden="true" class="h-5 w-5" />
               </span>
 
               <!-- Tag -->

--- a/components/pages/posts/navigation/DomainSelector.vue
+++ b/components/pages/posts/navigation/DomainSelector.vue
@@ -123,7 +123,7 @@
           v-if="!props.compact"
           class="pointer-events-none absolute inset-y-0 right-0 ml-3 flex items-center pr-2"
         >
-          <ChevronUpDownIcon class="h-5 w-5" />
+          <ChevronUpDownIcon aria-hidden="true" class="h-5 w-5" />
         </span>
       </HeadlessListboxButton>
 
@@ -171,7 +171,7 @@
                 v-if="selected"
                 class="text-base-content-highlight"
               >
-                <CheckIcon class="h-5 w-5" />
+                <CheckIcon aria-hidden="true" class="h-5 w-5" />
               </span>
             </div>
           </li>
@@ -179,7 +179,7 @@
 
         <!-- Add more button -->
         <div class="hover:hover-text-util hover:hover-bg-util group flex items-center px-3 py-2">
-          <PlusIcon class="group-hover:hover-text-util h-5 w-5 rounded-sm" />
+          <PlusIcon aria-hidden="true" class="group-hover:hover-text-util h-5 w-5 rounded-sm" />
 
           <NuxtLink
             :href="isPremium ? '/premium/additional-boorus' : '/premium'"

--- a/components/pages/posts/navigation/DomainSelectorFallback.vue
+++ b/components/pages/posts/navigation/DomainSelectorFallback.vue
@@ -42,7 +42,7 @@
       v-if="!props.compact"
       class="pointer-events-none absolute inset-y-0 right-0 ml-3 flex items-center pr-2"
     >
-      <ChevronUpDownIcon class="h-5 w-5" />
+      <ChevronUpDownIcon aria-hidden="true" class="h-5 w-5" />
     </span>
   </div>
 </template>

--- a/components/pages/posts/navigation/search/SearchMenu.vue
+++ b/components/pages/posts/navigation/search/SearchMenu.vue
@@ -176,7 +176,7 @@
       <div class="group relative mt-4">
         <!-- Icon -->
         <div class="group pointer-events-none absolute inset-y-0 left-0 flex items-center rounded-l-md px-2">
-          <MagnifyingGlassIcon class="text-base-content group-hover:text-base-content-hover h-5 w-5" />
+          <MagnifyingGlassIcon aria-hidden="true" class="text-base-content group-hover:text-base-content-hover h-5 w-5" />
         </div>
 
         <!-- Input -->
@@ -191,7 +191,7 @@
           ref="comboboxButtonRef"
           class="absolute inset-y-0 right-0 flex items-center rounded-r-md px-2"
         >
-          <ChevronUpDownIcon class="text-base-content group-hover:text-base-content-hover h-5 w-5" />
+          <ChevronUpDownIcon aria-hidden="true" class="text-base-content group-hover:text-base-content-hover h-5 w-5" />
         </HeadlessComboboxButton>
 
         <!-- Options -->
@@ -218,7 +218,7 @@
                 v-if="selected"
                 class="text-base-content-highlight absolute inset-y-0 left-0 flex items-center pl-1.5"
               >
-                <CheckIcon class="h-5 w-5" />
+                <CheckIcon aria-hidden="true" class="h-5 w-5" />
               </span>
             </div>
           </HeadlessComboboxOption>
@@ -239,7 +239,7 @@
                 v-if="selected"
                 class="text-base-content-highlight absolute inset-y-0 left-0 flex items-center pl-1.5"
               >
-                <CheckIcon class="h-5 w-5" />
+                <CheckIcon aria-hidden="true" class="h-5 w-5" />
               </span>
 
               <!-- Tag -->
@@ -270,7 +270,7 @@
           type="button"
           @click="isTagCollectionsActive = !isTagCollectionsActive"
         >
-          <TagIcon class="-ml-0.5 h-[1.15rem] w-[1.15rem]" />
+          <TagIcon aria-hidden="true" class="-ml-0.5 h-[1.15rem] w-[1.15rem]" />
 
           <span class="text-sm font-medium whitespace-nowrap">Collections</span>
         </button>
@@ -340,11 +340,13 @@
           >
             <NoSymbolIcon
               v-if="!isTagExcluded(tag.name)"
+              aria-hidden="true"
               class="h-4 w-4"
             />
 
             <PlusIcon
               v-else
+              aria-hidden="true"
               class="h-4 w-4"
             />
           </button>

--- a/components/pages/posts/navigation/search/SearchMenuWrapper.vue
+++ b/components/pages/posts/navigation/search/SearchMenuWrapper.vue
@@ -56,7 +56,7 @@
                   type="button"
                   @click="toggleSearchMenu(false)"
                 >
-                  <XMarkIcon class="hover:hover-text-util text-base-content-highlight h-6 w-6" />
+                  <XMarkIcon aria-hidden="true" class="hover:hover-text-util text-base-content-highlight h-6 w-6" />
                 </button>
               </div>
             </HeadlessTransitionChild>

--- a/components/pages/posts/navigation/search/TagCollections.vue
+++ b/components/pages/posts/navigation/search/TagCollections.vue
@@ -80,7 +80,7 @@
       >
         <span class="sr-only"> Manage tag collections </span>
 
-        <Cog6ToothIcon class="h-6 w-6" />
+        <Cog6ToothIcon aria-hidden="true" class="h-6 w-6" />
       </NuxtLink>
     </div>
 
@@ -106,7 +106,7 @@
                 {{ tagCollection.tags.length }}
               </span>
 
-              <TagIcon class="h-5 w-5" />
+              <TagIcon aria-hidden="true" class="h-5 w-5" />
             </div>
           </button>
         </li>
@@ -121,7 +121,7 @@
           >
             <span class="whitespace-nowrap">Create from current tags</span>
 
-            <PlusIcon class="h-5 w-5" />
+            <PlusIcon aria-hidden="true" class="h-5 w-5" />
           </button>
         </li>
       </ol>

--- a/components/pages/posts/post/PostDownload.vue
+++ b/components/pages/posts/post/PostDownload.vue
@@ -47,6 +47,6 @@
     type="button"
     @click="downloadMedia"
   >
-    <ArrowDownTrayIcon class="group-hover:hover-text-util text-base-content h-5 w-5" />
+    <ArrowDownTrayIcon aria-hidden="true" class="group-hover:hover-text-util text-base-content h-5 w-5" />
   </button>
 </template>

--- a/components/pages/posts/post/PostSaveFallback.vue
+++ b/components/pages/posts/post/PostSaveFallback.vue
@@ -8,6 +8,6 @@
     class="hover:hover-bg-util focus-visible:focus-outline-util group rounded-md px-1.5 py-1"
     type="button"
   >
-    <BookmarkIcon class="group-hover:hover-text-util text-base-content h-5 w-5" />
+    <BookmarkIcon aria-hidden="true" class="group-hover:hover-text-util text-base-content h-5 w-5" />
   </button>
 </template>

--- a/components/pages/posts/post/PostSource.vue
+++ b/components/pages/posts/post/PostSource.vue
@@ -117,7 +117,7 @@
         class="hover:hover-bg-util focus-visible:focus-outline-util group flex items-center rounded-md px-1.5 py-1"
         @click="onMenuOpen"
       >
-        <LinkIcon class="group-hover:hover-text-util text-base-content h-5 w-5" />
+        <LinkIcon aria-hidden="true" class="group-hover:hover-text-util text-base-content h-5 w-5" />
       </HeadlessMenuButton>
 
       <HeadlessMenuItems

--- a/components/pages/posts/post/PostTag.vue
+++ b/components/pages/posts/post/PostTag.vue
@@ -110,6 +110,7 @@
             >
               <component
                 :is="isTagInSelectedTags(tag) ? MinusIcon : PlusIcon"
+                aria-hidden="true"
                 class="mr-3 h-4 w-4 shrink-0 rounded-sm"
               />
 
@@ -127,7 +128,7 @@
               type="button"
               @click="emit('addTag', '-' + props.tag.name)"
             >
-              <NoSymbolIcon class="mr-3 h-4 w-4 shrink-0 rounded-sm" />
+              <NoSymbolIcon aria-hidden="true" class="mr-3 h-4 w-4 shrink-0 rounded-sm" />
 
               Exclude tag
             </button>
@@ -143,7 +144,7 @@
               type="button"
               @click="emit('setTag', props.tag.name)"
             >
-              <MagnifyingGlassIcon class="mr-3 h-4 w-4 shrink-0 rounded-sm" />
+              <MagnifyingGlassIcon aria-hidden="true" class="mr-3 h-4 w-4 shrink-0 rounded-sm" />
 
               Set tag
             </button>
@@ -159,7 +160,7 @@
               type="button"
               @click="toggleBlockedTag(tag)"
             >
-              <ShieldExclamationIcon class="mr-3 h-4 w-4 shrink-0 rounded-sm" />
+              <ShieldExclamationIcon aria-hidden="true" class="mr-3 h-4 w-4 shrink-0 rounded-sm" />
               {{ isTagBlocked(tag) ? 'Remove from blocklist' : 'Add to blocklist' }}
             </button>
           </HeadlessMenuItem>
@@ -174,7 +175,7 @@
               type="button"
               @click="emit('openTagInNewTab', props.tag.name)"
             >
-              <ArrowTopRightOnSquareIcon class="mr-3 h-4 w-4 shrink-0 rounded-sm" />
+              <ArrowTopRightOnSquareIcon aria-hidden="true" class="mr-3 h-4 w-4 shrink-0 rounded-sm" />
 
               Open in new tab
             </button>

--- a/components/pages/settings/SettingSelect.vue
+++ b/components/pages/settings/SettingSelect.vue
@@ -46,7 +46,7 @@
       >
         {{ modelValue }}
 
-        <ChevronDownIcon class="-mr-0.5 h-5 w-5 text-base-content" />
+        <ChevronDownIcon aria-hidden="true" class="-mr-0.5 h-5 w-5 text-base-content" />
       </HeadlessListboxButton>
 
       <HeadlessListboxOptions
@@ -71,7 +71,7 @@
                   v-if="selected"
                   :class="active ? 'text-base-content-highlight' : 'text-base-content'"
                 >
-                  <CheckIcon class="h-5 w-5" />
+                  <CheckIcon aria-hidden="true" class="h-5 w-5" />
                 </span>
               </div>
             </div>

--- a/pages/posts/[domain].vue
+++ b/pages/posts/[domain].vue
@@ -852,7 +852,7 @@
         type="button"
         @click="toggleSearchMenu()"
       >
-        <MagnifyingGlassIcon class="text-base-content-highlight h-6 w-6" />
+        <MagnifyingGlassIcon aria-hidden="true" class="text-base-content-highlight h-6 w-6" />
 
         <!-- Highlighter -->
         <span
@@ -923,7 +923,7 @@
           class="flex h-80 w-full animate-pulse flex-col items-center justify-center gap-4 text-lg"
           data-testid="posts-loader"
         >
-          <ArrowPathIcon class="h-12 w-12 animate-spin" />
+          <ArrowPathIcon aria-hidden="true" class="h-12 w-12 animate-spin" />
 
           <h3>Loading posts&hellip;</h3>
         </div>
@@ -932,7 +932,7 @@
       <!-- Error -->
       <template v-else-if="isError">
         <div class="mt-12 text-center">
-          <ExclamationCircleIcon class="mx-auto mb-1 h-12 w-12" />
+          <ExclamationCircleIcon aria-hidden="true" class="mx-auto mb-1 h-12 w-12" />
 
           <div v-if="error.status === 404">
             <h3 class="text-lg leading-10 font-semibold">No posts found</h3>
@@ -979,7 +979,7 @@
       <!-- No results -->
       <template v-else-if="!allRows.length">
         <div class="flex h-80 w-full flex-col items-center justify-center gap-4 text-lg">
-          <QuestionMarkCircleIcon class="h-12 w-12" />
+          <QuestionMarkCircleIcon aria-hidden="true" class="h-12 w-12" />
 
           <h3>No results</h3>
 

--- a/pages/premium/additional-boorus.vue
+++ b/pages/premium/additional-boorus.vue
@@ -190,7 +190,7 @@
     <section class="mx-2 mt-4 flex-auto">
       <template v-if="!userBooruList.length">
         <div class="flex h-80 w-full flex-col items-center justify-center gap-4 text-center text-lg">
-          <ExclamationCircleIcon class="h-12 w-12" />
+          <ExclamationCircleIcon aria-hidden="true" class="h-12 w-12" />
 
           <h3>Start adding Boorus!</h3>
 
@@ -213,7 +213,7 @@
             <div class="handle mr-2 cursor-move">
               <span class="sr-only">Drag to reorder</span>
 
-              <Bars2Icon class="text-base-content group-hover:text-base-content-hover h-4 w-4" />
+              <Bars2Icon aria-hidden="true" class="text-base-content group-hover:text-base-content-hover h-4 w-4" />
             </div>
 
             <!-- Favicon -->
@@ -242,7 +242,7 @@
                 type="button"
                 @click="openEditBooru(index)"
               >
-                <PencilIcon class="h-4 w-4" />
+                <PencilIcon aria-hidden="true" class="h-4 w-4" />
               </button>
             </div>
           </li>
@@ -258,7 +258,7 @@
         type="button"
         @click="resetUserBooruListToDefault"
       >
-        <ArrowUturnLeftIcon class="mr-2 h-4 w-4" />
+        <ArrowUturnLeftIcon aria-hidden="true" class="mr-2 h-4 w-4" />
 
         Reset
       </button>
@@ -271,7 +271,7 @@
       >
         Add Booru
 
-        <PlusIcon class="mr-2 ml-2 h-4 w-4" />
+        <PlusIcon aria-hidden="true" class="mr-2 ml-2 h-4 w-4" />
       </button>
     </section>
   </main>

--- a/pages/premium/dashboard.vue
+++ b/pages/premium/dashboard.vue
@@ -166,7 +166,7 @@
       class="border-base-0/20 mt-4 rounded-md border p-4 text-sm text-pretty"
     >
       <div class="mb-2 flex items-center gap-2">
-        <ExclamationTriangleIcon class="h-6 w-6 text-yellow-400" />
+        <ExclamationTriangleIcon aria-hidden="true" class="h-6 w-6 text-yellow-400" />
         <h2 class="text-base font-medium">Your subscription has expired</h2>
       </div>
 

--- a/pages/premium/index.vue
+++ b/pages/premium/index.vue
@@ -374,7 +374,7 @@
                       :key="mainFeature.title"
                       class="flex items-center gap-x-3 py-2"
                     >
-                      <CheckIcon class="text-primary-600 h-6 w-5 flex-none" />
+                      <CheckIcon aria-hidden="true" class="text-primary-600 h-6 w-5 flex-none" />
 
                       <span class="text-base-content-highlight flex-auto text-sm leading-6">
                         {{ mainFeature.title }}

--- a/pages/premium/saved-posts/[domain].vue
+++ b/pages/premium/saved-posts/[domain].vue
@@ -664,7 +664,7 @@
         type="button"
         @click="toggleSearchMenu()"
       >
-        <MagnifyingGlassIcon class="text-base-content-highlight h-6 w-6" />
+        <MagnifyingGlassIcon aria-hidden="true" class="text-base-content-highlight h-6 w-6" />
 
         <!-- Highlighter -->
         <span
@@ -729,7 +729,7 @@
           class="flex h-80 w-full animate-pulse flex-col items-center justify-center gap-4 text-lg"
           data-testid="posts-loader"
         >
-          <ArrowPathIcon class="h-12 w-12 animate-spin" />
+          <ArrowPathIcon aria-hidden="true" class="h-12 w-12 animate-spin" />
 
           <h3>Loading posts&hellip;</h3>
         </div>
@@ -738,7 +738,7 @@
       <!-- Error -->
       <template v-else-if="isError">
         <div class="mt-12 text-center">
-          <ExclamationCircleIcon class="mx-auto mb-1 h-12 w-12" />
+          <ExclamationCircleIcon aria-hidden="true" class="mx-auto mb-1 h-12 w-12" />
 
           <div v-if="error.status === 404">
             <h3 class="text-lg leading-10 font-semibold">No posts found</h3>
@@ -785,7 +785,7 @@
       <!-- No results -->
       <template v-else-if="!allRows.length">
         <div class="flex h-80 w-full flex-col items-center justify-center gap-4 text-lg">
-          <QuestionMarkCircleIcon class="h-12 w-12" />
+          <QuestionMarkCircleIcon aria-hidden="true" class="h-12 w-12" />
 
           <h3>No results</h3>
 

--- a/pages/premium/tag-collections.vue
+++ b/pages/premium/tag-collections.vue
@@ -169,7 +169,7 @@
           <div class="handle mr-2 cursor-move">
             <span class="sr-only">Drag to reorder</span>
 
-            <Bars2Icon class="text-base-content group-hover:text-base-content-hover h-4 w-4" />
+            <Bars2Icon aria-hidden="true" class="text-base-content group-hover:text-base-content-hover h-4 w-4" />
           </div>
 
           <!-- Tag Length -->
@@ -198,7 +198,7 @@
               type="button"
               @click="openEditDialog(index)"
             >
-              <PencilIcon class="h-4 w-4" />
+              <PencilIcon aria-hidden="true" class="h-4 w-4" />
             </button>
           </div>
         </li>
@@ -213,7 +213,7 @@
         type="button"
         @click="resetTagCollectionsToDefault"
       >
-        <ArrowUturnLeftIcon class="mr-2 h-4 w-4" />
+        <ArrowUturnLeftIcon aria-hidden="true" class="mr-2 h-4 w-4" />
 
         Reset to default
       </button>
@@ -226,7 +226,7 @@
       >
         Create collection
 
-        <PlusIcon class="mr-2 ml-2 h-4 w-4" />
+        <PlusIcon aria-hidden="true" class="mr-2 ml-2 h-4 w-4" />
       </button>
     </section>
   </main>

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -201,7 +201,7 @@
       <label for="reset">
         <span class="text-base-content-highlight leading-8 font-medium">
           Reset
-          <ExclamationTriangleIcon class="inline-block h-4 w-4" />
+          <ExclamationTriangleIcon aria-hidden="true" class="inline-block h-4 w-4" />
         </span>
 
         <span class="block text-sm"> Clear settings, cookies, and all other app data </span>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved accessibility across multiple pages and components by marking decorative icons as hidden from assistive technologies. This ensures that screen readers ignore icons used purely for visual purposes, enhancing the user experience for those relying on accessibility tools. No changes were made to functionality or layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->