### PR TITLE
Update Nuxt runtime config to use camelCase and NUXT_ prefix

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -6,14 +6,14 @@ PORT=8080
 NODE_ENV=development
 
 # API Configuration
-API_URL=http://localhost:8081
+NUXT_PUBLIC_API_URL=http://localhost:8081
 
 # Matomo Analytics
-MATOMO_API_KEY=
+NUXT_MATOMO_API_KEY=
 
 # Sentry Error Tracking
 # https://sentry.io/
-SENTRY_DSN=
+NUXT_PUBLIC_SENTRY_DSN=
 SENTRY_ORG=
 SENTRY_PROJECT=
 SENTRY_AUTH_TOKEN=

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,8 @@ ENV NODE_ENV=production
 
 WORKDIR /app
 
+RUN apk add --no-cache tini
+
 # Nuxt/Nitro bundles all dependencies, so node_modules is not needed
 COPY --from=builder --chown=node:node /app/.output ./.output
 
@@ -39,5 +41,5 @@ EXPOSE 3000
 
 HEALTHCHECK CMD wget --no-verbose --spider http://127.0.0.1:3000/ || exit 1
 
-# Use `docker run --init` or `init: true` in compose for proper signal handling
+ENTRYPOINT ["/sbin/tini", "--"]
 CMD ["node", ".output/server/index.mjs"]

--- a/app.vue
+++ b/app.vue
@@ -52,7 +52,7 @@
       // Preconnect to API
       {
         rel: 'preconnect',
-        href: runtimeConfig.public.API_URL
+        href: runtimeConfig.public.apiUrl
       }
     ]
   })

--- a/components/PostPageError.vue
+++ b/components/PostPageError.vue
@@ -32,7 +32,7 @@
       </span>
 
       <NuxtLink
-        :href="config.public.API_URL + '/status'"
+        :href="config.public.apiUrl + '/status'"
         class="focus-visible:focus-outline-util hover:hover-bg-util hover:hover-text-util ring-base-0/20 mx-auto mt-4 block w-fit rounded-md px-6 py-1.5 text-base ring-1 focus-visible:ring-offset-2"
         rel="nofollow noopener noreferrer"
         target="_blank"

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -241,18 +241,11 @@ _paq.push(['setExcludedQueryParams', ['page', 'cursor']])
   sourcemap: { client: 'hidden' },
 
   runtimeConfig: {
-    MATOMO_API_KEY: process.env.MATOMO_API_KEY,
-
-    SENTRY_ORG: process.env.SENTRY_ORG,
-    SENTRY_PROJECT: process.env.SENTRY_PROJECT,
-    SENTRY_AUTH_TOKEN: process.env.SENTRY_AUTH_TOKEN,
+    matomoApiKey,
 
     public: {
-      NODE_ENV: process.env.NODE_ENV,
-
-      API_URL: process.env.API_URL,
-
-      SENTRY_DSN: process.env.SENTRY_DSN
+      apiUrl,
+      sentryDsn
     }
   },
 

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -241,11 +241,11 @@ _paq.push(['setExcludedQueryParams', ['page', 'cursor']])
   sourcemap: { client: 'hidden' },
 
   runtimeConfig: {
-    matomoApiKey,
+    matomoApiKey: undefined,
 
     public: {
-      apiUrl,
-      sentryDsn
+      apiUrl: undefined,
+      sentryDsn: undefined
     }
   },
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -51,7 +51,7 @@
   const searchTagResults: Ref<Tag[]> = shallowRef([])
 
   async function onSearchTag(tag: string) {
-    const apiUrl = config.public.API_URL + '/booru/' + selectedBooru.value.type.type + '/tags'
+    const apiUrl = config.public.apiUrl + '/booru/' + selectedBooru.value.type.type + '/tags'
 
     const response = await $fetch(apiUrl, {
       params: {
@@ -83,7 +83,7 @@
             description: 'You sent too many requests in a short period of time',
             action: {
               label: 'Verify I am not a Bot',
-              onClick: () => window.open(config.public.API_URL + '/status', '_blank')
+              onClick: () => window.open(config.public.apiUrl + '/status', '_blank')
             }
           })
           break

--- a/pages/posts/[domain].vue
+++ b/pages/posts/[domain].vue
@@ -211,7 +211,7 @@
    * Listeners
    */
   async function onSearchTag(tag: string) {
-    const apiUrl = config.public.API_URL + '/booru/' + selectedBooru.value.type.type + '/tags'
+    const apiUrl = config.public.apiUrl + '/booru/' + selectedBooru.value.type.type + '/tags'
 
     const response = await $fetch(apiUrl, {
       params: {
@@ -244,7 +244,7 @@
             description: 'You sent too many requests in a short period of time',
             action: {
               label: 'Verify I am not a Bot',
-              onClick: () => window.open(config.public.API_URL + '/status', '_blank')
+              onClick: () => window.open(config.public.apiUrl + '/status', '_blank')
             }
           })
           break
@@ -386,7 +386,7 @@
       })
     }
 
-    const apiUrl = config.public.API_URL + '/booru/' + selectedBooru.value.type.type + '/posts'
+    const apiUrl = config.public.apiUrl + '/booru/' + selectedBooru.value.type.type + '/posts'
 
     const tags = selectedTags.value.map((tag) => tag.name).join('|')
 

--- a/plugins/030.pocketbase.ts
+++ b/plugins/030.pocketbase.ts
@@ -2,8 +2,6 @@ import PocketBase from 'pocketbase'
 
 // https://github.com/pocketbase/js-sdk#ssr-integration
 export default defineNuxtPlugin(async ({ app }) => {
-  const config = useRuntimeConfig()
-
   const pb = new PocketBase('https://pocketbase.r34.app')
 
   // TODO: Store in localStorage for better caching

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -6,7 +6,7 @@ const config = useRuntimeConfig()
 Sentry.init({
   enabled: !import.meta.dev,
 
-  dsn: config.public.SENTRY_DSN,
+  dsn: config.public.sentryDsn,
 
   tracesSampleRate: 0.2,
 

--- a/server/api/_sitemap-urls.ts
+++ b/server/api/_sitemap-urls.ts
@@ -37,7 +37,7 @@ interface MatomoErrorResponse {
 
 async function getPopularSiteSearchKeywordsFromMatomoApi(): Promise<MatomoResponse[]> {
   const baseUrl = `https://matomo.akbal.dev/`
-  const apiToken = config.MATOMO_API_KEY
+  const apiToken = config.matomoApiKey
 
   const siteId = 1
   const period = 'month'


### PR DESCRIPTION
## Summary

Update Nuxt runtime config to follow Nuxt conventions for environment variable naming. Configuration now uses camelCase keys with the `NUXT_PUBLIC_` and `NUXT_` prefixes for proper runtime override support.

## Changes

- Updated `runtimeConfig` keys to camelCase (`API_URL` → `apiUrl`, `MATOMO_API_KEY` → `matomoApiKey`, etc.)
- Removed `process.env` references from config to enable Nuxt's auto-population from environment variables
- Updated all usages across components and pages to use new camelCase keys
- Updated `.example.env` to use `NUXT_PUBLIC_*` and `NUXT_*` prefixes
- Removed unused `useRuntimeConfig()` from pocketbase plugin

## Environment Variables

Runtime overrides now use:
- `NUXT_PUBLIC_API_URL` - Backend API endpoint
- `NUXT_PUBLIC_SENTRY_DSN` - Sentry error tracking
- `NUXT_MATOMO_API_KEY` - Matomo analytics

Example: `docker run -e NUXT_PUBLIC_API_URL=https://api.example.com ...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized runtime configuration keys for API, telemetry, and analytics; updated all runtime references so links, preconnects, status pages and telemetry read from the new properties. No user-facing behavior changes.
  * Docker startup now runs under an init process for more reliable container start/shutdown.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->