### PR TITLE
fix(download): use quality-ordered URL chain to prevent low-res downl…

### DIFF
--- a/components/pages/posts/post/PostComponent.vue
+++ b/components/pages/posts/post/PostComponent.vue
@@ -134,7 +134,7 @@
         <PostDownload
           v-if="mediaFile.file"
           :mediaName="`${post.domain}-${post.id}`"
-          :mediaUrl="mediaFile.file"
+          :mediaUrl="post.high_res_file.url ?? post.low_res_file.url ?? (mediaFile.file as string)"
         />
 
         <PostSource


### PR DESCRIPTION
…oads

When high_res_file.url is null (e.g. Pocketbase saved posts), fall back to low_res_file.url before falling back to the display-setting-dependent mediaFile.file. This prevents the premium download button from downloading a sample/low-res file when postFullSizeImages is disabled.

Fixes https://feedback.r34.app/posts/460

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media URL handling in post downloads with enhanced fallback logic, ensuring more reliable access to media files and preferring higher-resolution versions when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->