### PR TITLE
fix: encode ampersands in post tag routes

### DIFF
--- a/assets/js/RouterHelper.ts
+++ b/assets/js/RouterHelper.ts
@@ -1,4 +1,4 @@
-import Tag from '~/assets/js/tag.dto'
+import Tag from './tag.dto'
 import type { RouteLocationRaw } from 'vue-router'
 
 export function generatePostsRoute(
@@ -22,7 +22,7 @@ export function generatePostsRoute(
   }
 
   if (tags != null && Array.isArray(tags) && tags.length) {
-    route.query.tags = tags.map((tag) => encodeURI(tag.name)).join('|')
+    route.query.tags = tags.map((tag) => encodeURIComponent(tag.name)).join('|')
   }
 
   // Check if object keys are not undefined

--- a/components/pages/home/PageHistory.vue
+++ b/components/pages/home/PageHistory.vue
@@ -14,7 +14,14 @@
         .split('&')
         .map(
           (_query) => {
-            const query = decodeURIComponent(_query)
+            let query = _query
+
+            try {
+              query = decodeURIComponent(_query)
+            }
+            catch {
+              // Keep raw query when percent-encoding is malformed
+            }
 
             return (
               query

--- a/components/pages/home/PageHistory.vue
+++ b/components/pages/home/PageHistory.vue
@@ -6,8 +6,6 @@
   const { pageHistory } = usePageHistory()
 
   function historyPathToTitle(path: string) {
-    path = decodeURIComponent(path)
-
     return (
       path
         //
@@ -15,16 +13,21 @@
         .replace('?', '&')
         .split('&')
         .map(
-          (_query) =>
-            _query
-              // Capitalize first character
-              .charAt(0)
-              .toUpperCase() +
-            _query
-              .slice(1)
+          (_query) => {
+            const query = decodeURIComponent(_query)
 
-              // Replace first '=' with ': '
-              .replace(/=/, ': ')
+            return (
+              query
+                // Capitalize first character
+                .charAt(0)
+                .toUpperCase() +
+              query
+                .slice(1)
+
+                // Replace first '=' with ': '
+                .replace(/=/, ': ')
+            )
+          }
         )
         // Query separator
         .join('\n')

--- a/test/assets/router-helper.test.ts
+++ b/test/assets/router-helper.test.ts
@@ -21,4 +21,28 @@ describe('generatePostsRoute', () => {
 
     expect(decodeURIComponent(String(route.query?.tags))).toBe('panty_&_stocking_with_garterbelt')
   })
+
+  it('encodes multiple tags joined by pipes when one contains an ampersand', () => {
+    const route = generatePostsRoute(
+      '/posts',
+      'safebooru.org',
+      undefined,
+      [
+        new Tag({ name: 'panty_&_stocking_with_garterbelt' }),
+        new Tag({ name: 'rating:safe' })
+      ],
+      undefined
+    )
+
+    expect(route).toMatchObject({
+      path: '/posts/safebooru.org',
+      query: {
+        tags: 'panty_%26_stocking_with_garterbelt|rating%3Asafe'
+      }
+    })
+
+    expect(decodeURIComponent(String(route.query?.tags))).toBe(
+      'panty_&_stocking_with_garterbelt|rating:safe'
+    )
+  })
 })

--- a/test/assets/router-helper.test.ts
+++ b/test/assets/router-helper.test.ts
@@ -1,0 +1,24 @@
+import {describe, expect, it} from 'vitest'
+import {generatePostsRoute} from '../../assets/js/RouterHelper'
+import Tag from '../../assets/js/tag.dto'
+
+describe('generatePostsRoute', () => {
+  it('encodes ampersands in tag query values', () => {
+    const route = generatePostsRoute(
+      '/posts',
+      'safebooru.org',
+      undefined,
+      [new Tag({ name: 'panty_&_stocking_with_garterbelt' })],
+      undefined
+    )
+
+    expect(route).toMatchObject({
+      path: '/posts/safebooru.org',
+      query: {
+        tags: 'panty_%26_stocking_with_garterbelt'
+      }
+    })
+
+    expect(decodeURIComponent(String(route.query?.tags))).toBe('panty_&_stocking_with_garterbelt')
+  })
+})


### PR DESCRIPTION
## Summary
- encode post tag route query values with `encodeURIComponent` so tags containing `&` no longer break the `tags` query string
- add a focused `RouterHelper` regression test covering `panty_&_stocking_with_garterbelt`
- validate with `pnpm exec vitest run test/assets/router-helper.test.ts`

## Issue
- Closes feedback issue #326

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL-encoding of tag names (uses stricter encoding) so routes and queries work correctly with special characters (e.g., ampersands).
* **Refactor**
  * History path-to-title logic now decodes each query segment individually and preserves raw segments on malformed encoding for more reliable display.
* **Tests**
  * Added unit tests verifying encoding/decoding for single and multiple tag queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->