### PR TITLE
feat: export active block list from settings

### DIFF
--- a/assets/js/DownloadHelper.ts
+++ b/assets/js/DownloadHelper.ts
@@ -1,0 +1,16 @@
+export function downloadBlob(blob: Blob, filename: string) {
+  const objectURL = window.URL.createObjectURL(blob)
+
+  const anchorElement = document.createElement('a')
+
+  anchorElement.href = objectURL
+  anchorElement.download = filename
+  anchorElement.style.display = 'none'
+
+  document.body.appendChild(anchorElement)
+  anchorElement.click()
+
+  anchorElement.remove()
+
+  setTimeout(() => window.URL.revokeObjectURL(objectURL), 100)
+}

--- a/pages/premium/backup.vue
+++ b/pages/premium/backup.vue
@@ -1,30 +1,12 @@
 <script lang="ts" setup>
   import { ArrowDownTrayIcon, ArrowUturnLeftIcon } from '@heroicons/vue/24/solid'
   import { toast } from 'vue-sonner'
+  import { downloadBlob } from '~/assets/js/DownloadHelper'
   import { createBackupState, type IBackupState, tryToRestoreV2OrV3Backup } from '~/assets/js/BackupHelper'
   import PageHeader from '~/components/layout/PageHeader.vue'
   import { project } from '@/config/project'
 
   const fileInputElement = ref<HTMLInputElement | null>(null)
-
-  function downloadBlob(blob: Blob, filename: string) {
-    const objectURL = window.URL.createObjectURL(blob)
-
-    // Create anchor element
-    const anchorElement = document.createElement('a')
-
-    anchorElement.href = objectURL
-    anchorElement.target = '_blank'
-    anchorElement.download = filename
-    anchorElement.style.display = 'none'
-
-    // Download
-    anchorElement.click()
-
-    // Clean up
-    anchorElement.remove()
-    window.URL.revokeObjectURL(objectURL)
-  }
 
   async function createBackup() {
     const currentDateString = new Date()

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -215,24 +215,24 @@
                 rows="4"
               />
 
-              <button
-                class="hover:hover-bg-util focus-visible:focus-outline-util hover:hover-text-util ring-base-0/20 self-end rounded-lg px-3 py-1.5 text-sm font-medium ring-1 transition-colors focus-visible:ring-inset"
-                type="submit"
-              >
-                Save
-              </button>
+              <div class="flex justify-end gap-2">
+                <button
+                  class="hover:hover-bg-util focus-visible:focus-outline-util hover:hover-text-util ring-base-0/20 rounded-lg px-3 py-1.5 text-sm font-medium ring-1 transition-colors focus-visible:ring-inset"
+                  type="button"
+                  @click="exportBlockList"
+                >
+                  Export .txt
+                </button>
+
+                <button
+                  class="hover:hover-bg-util focus-visible:focus-outline-util hover:hover-text-util ring-base-0/20 rounded-lg px-3 py-1.5 text-sm font-medium ring-1 transition-colors focus-visible:ring-inset"
+                  type="submit"
+                >
+                  Save
+                </button>
+              </div>
             </form>
           </template>
-
-          <div class="mt-2 flex justify-end">
-            <button
-              class="hover:hover-bg-util focus-visible:focus-outline-util hover:hover-text-util ring-base-0/20 rounded-lg px-3 py-1.5 text-sm font-medium ring-1 transition-colors focus-visible:ring-inset"
-              type="button"
-              @click="exportBlockList"
-            >
-              Export .txt
-            </button>
-          </div>
         </li>
 
         <!-- blockAiGeneratedImages -->

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -2,6 +2,7 @@
   import { version } from '~/package.json'
   import { ExclamationTriangleIcon } from '@heroicons/vue/20/solid'
   import { toast } from 'vue-sonner'
+  import { downloadBlob } from '~/assets/js/DownloadHelper'
   import { project } from '@/config/project'
 
   useSeoMeta({
@@ -48,23 +49,6 @@
     customBlockList.value = tags
 
     toast.success('Custom block list saved')
-  }
-
-  function downloadBlob(blob: Blob, filename: string) {
-    const objectURL = window.URL.createObjectURL(blob)
-
-    const anchorElement = document.createElement('a')
-
-    anchorElement.href = objectURL
-    anchorElement.download = filename
-    anchorElement.style.display = 'none'
-
-    document.body.appendChild(anchorElement)
-    anchorElement.click()
-
-    anchorElement.remove()
-
-    setTimeout(() => window.URL.revokeObjectURL(objectURL), 100)
   }
 
   function exportBlockList() {

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -1,10 +1,10 @@
 <script lang="ts" setup>
-import { version } from '~/package.json'
-import { ExclamationTriangleIcon } from '@heroicons/vue/20/solid'
-import { toast } from 'vue-sonner'
-import { project } from '@/config/project'
+  import { version } from '~/package.json'
+  import { ExclamationTriangleIcon } from '@heroicons/vue/20/solid'
+  import { toast } from 'vue-sonner'
+  import { project } from '@/config/project'
 
-useSeoMeta({
+  useSeoMeta({
     title: 'Settings',
 
     description: `Options to configure how ${project.name} works.`
@@ -14,7 +14,7 @@ useSeoMeta({
 
   const { postFullSizeImages, postsPerPage, autoplayAnimatedMedia, blockAiGeneratedImages } = useUserSettings()
   const { isPremium } = useUserData()
-  const { selectedList, defaultBlockList, customBlockList, resetCustomBlockList } = useBlockLists()
+  const { selectedList, selectedBlockList, defaultBlockList, customBlockList, resetCustomBlockList } = useBlockLists()
 
   function onSelectedListChange(value: blockListOptions) {
     if (value === blockListOptions.Custom && !isPremium.value) {
@@ -48,6 +48,35 @@ useSeoMeta({
     customBlockList.value = tags
 
     toast.success('Custom block list saved')
+  }
+
+  function downloadBlob(blob: Blob, filename: string) {
+    const objectURL = window.URL.createObjectURL(blob)
+
+    const anchorElement = document.createElement('a')
+
+    anchorElement.href = objectURL
+    anchorElement.target = '_blank'
+    anchorElement.download = filename
+    anchorElement.style.display = 'none'
+
+    anchorElement.click()
+
+    anchorElement.remove()
+    window.URL.revokeObjectURL(objectURL)
+  }
+
+  function exportBlockList() {
+    if (selectedBlockList.value.length === 0) {
+      toast.error('No blocked tags to export')
+      return
+    }
+
+    const blob = new Blob([selectedBlockList.value.join('\n')], { type: 'text/plain;charset=utf-8' })
+    const fileName = `${project.urls.production.hostname}_Blocklist.txt`
+
+    downloadBlob(blob, fileName)
+    toast.success('Block list exported')
   }
 
   async function removeAllData() {
@@ -193,6 +222,16 @@ useSeoMeta({
               </button>
             </form>
           </template>
+
+          <div class="mt-2 flex justify-end">
+            <button
+              class="hover:hover-bg-util focus-visible:focus-outline-util hover:hover-text-util ring-base-0/20 rounded-lg px-3 py-1.5 text-sm font-medium ring-1 transition-colors focus-visible:ring-inset"
+              type="button"
+              @click="exportBlockList"
+            >
+              Export .txt
+            </button>
+          </div>
         </li>
 
         <!-- blockAiGeneratedImages -->

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -56,14 +56,15 @@
     const anchorElement = document.createElement('a')
 
     anchorElement.href = objectURL
-    anchorElement.target = '_blank'
     anchorElement.download = filename
     anchorElement.style.display = 'none'
 
+    document.body.appendChild(anchorElement)
     anchorElement.click()
 
     anchorElement.remove()
-    window.URL.revokeObjectURL(objectURL)
+
+    setTimeout(() => window.URL.revokeObjectURL(objectURL), 100)
   }
 
   function exportBlockList() {


### PR DESCRIPTION
## Summary
- add an `Export .txt` action to the settings block list section
- export the currently active block list as a newline-separated text file using the existing blob-download pattern
- show a toast instead of downloading an empty file when there are no blocked tags to export

## Validation
- `pnpm exec prettier --check \"pages/settings.vue\"`
- `pnpm build` *(fails on current branch and origin/main due to pre-existing `Buffer`/`__vite-browser-external` build issue in `assets/js/nuxt-image/imgproxy.provider.ts`)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Block List export: users can download their selected block list as a .txt file.
  * New Export .txt button in the Block List section alongside Save.
  * Export validates selection and shows success or error toasts for clear feedback.
* **UX**
  * Selection state now stays in sync so Export uses the currently selected block list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Feedback Post
- https://feedback.r34.app/posts/715/export-blocklist
