### PR TITLE
fix: guard saved posts random sort

### DIFF
--- a/pages/premium/saved-posts/[domain].vue
+++ b/pages/premium/saved-posts/[domain].vue
@@ -131,8 +131,7 @@
         { label: 'Score', value: '-score' },
         { label: 'Score (asc)', value: 'score' },
         { label: 'Created', value: '-created' },
-        { label: 'Created (asc)', value: 'created' },
-        { label: 'Random', value: '@random' }
+        { label: 'Created (asc)', value: 'created' }
       ]
     },
     rating: {
@@ -332,7 +331,7 @@
       })
     }
 
-    const pocketbaseRequestSort = selectedFilters.value.sort ?? '-created'
+    const pocketbaseRequestSort = selectedFilters.value.sort === '@random' ? '-created' : selectedFilters.value.sort ?? '-created'
 
     if (selectedFilters.value.rating) {
       if (pocketbaseRequestFilter !== '') {


### PR DESCRIPTION
## Summary
- remove the unsupported Random sort option from premium saved posts so the UI no longer offers a broken PocketBase query
- map legacy `@random` saved-posts URLs back to `-created` to avoid errors for existing links or cached filter state
- Feedback post: https://feedback.r34.app/posts/211/hi-when-i-sort-by-random-for-saved-images-under-premium-subscription-many-older-images-give-errors

## Validation
- `pnpm test` *(fails in this worktree because `vitest` is unavailable and `node_modules` is missing)*
- Vue LSP diagnostics unavailable in this environment because the Vue language server module is missing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the Random sort option from the Sort filter in saved posts view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->