### PR TITLE
fix: quiet tag autocomplete 503 errors

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -82,6 +82,8 @@
       })
 
     if (response instanceof FetchError) {
+      searchTagResults.value = []
+
       switch (response.status) {
         case 404:
           toast.error('No tags found for query "' + tag + '"')
@@ -95,6 +97,10 @@
               onClick: () => window.open(config.public.apiUrl + '/status', '_blank')
             }
           })
+          break
+
+        case 503:
+          // Upstream can briefly fail during autocomplete; avoid noisy error toasts while typing
           break
 
         default:

--- a/pages/posts/[domain].vue
+++ b/pages/posts/[domain].vue
@@ -242,6 +242,8 @@
       })
 
     if (response instanceof FetchError) {
+      tagResults.value = []
+
       switch (response.status) {
         case 404:
           toast.error('No tags found for query "' + tag + '"')
@@ -256,6 +258,10 @@
               onClick: () => window.open(config.public.apiUrl + '/status', '_blank')
             }
           })
+          break
+
+        case 503:
+          // Upstream can briefly fail during autocomplete; avoid noisy error toasts while typing
           break
 
         default:


### PR DESCRIPTION
## Summary
- clear stale tag autocomplete results when the upstream booru tag endpoint fails
- suppress noisy error toasts for transient 503 responses while users are typing tags on the home and posts pages
- feedback source: https://feedback.r34.app/?statuses=open&view=trending and https://feedback.r34.app/posts/394/error-503-because-of-tags

## Validation
- `pnpm test` *(fails in this worktree because `node_modules` is missing, so `vitest` is not available)*
- Vue LSP diagnostics could not run in this environment because the Vue language server module is unavailable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search error handling by clearing previous results when fetch errors occur.
  * Suppressed error notifications for temporary upstream issues (HTTP 503) during search operations to reduce noisy alerts while typing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->