### PR TITLE
fix: add persistent sign-in sidebar link

### DIFF
--- a/components/layout/navigation/Sidebar.vue
+++ b/components/layout/navigation/Sidebar.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { BookmarkIcon, SparklesIcon } from '@heroicons/vue/24/outline'
+import { ArrowRightOnRectangleIcon, BookmarkIcon, SparklesIcon } from '@heroicons/vue/24/outline'
 import { sidebarNavigation } from 'assets/js/sidebarLinks'
 import { project } from '@/config/project'
 
@@ -78,6 +78,19 @@ const { value: isMenuActive, toggle: toggleMenu } = useMenu()
           >
             <BookmarkIcon class="text-primary-500 h-6 w-6 shrink-0" />
             Saved Posts
+          </NuxtLink>
+        </li>
+      </template>
+
+      <template v-else>
+        <li class="-mr-2 ml-6">
+          <NuxtLink
+            href="/premium/sign-in"
+            class="focus-visible:focus-outline-util hover:hover-text-util hover:hover-bg-util group flex gap-x-3 rounded-md p-2 text-sm leading-6 font-semibold"
+            exactActiveClass="bg-base-0/20 text-base-content-highlight"
+          >
+            <ArrowRightOnRectangleIcon class="text-primary-500 h-6 w-6 shrink-0" />
+            Sign in
           </NuxtLink>
         </li>
       </template>


### PR DESCRIPTION
## Summary
- add a dedicated Sign in link under the Premium section of the sidebar for signed-out users
- keep Saved Posts visible only for premium users so premium navigation stays unchanged after login
- addresses feedback issue 291: https://feedback.r34.app/posts/291/login-is-too-hidden

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Non-premium users now see a Sign in link in the Premium section of the sidebar navigation, providing quick access to authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->