### PR TITLE
fix: retry premium media proxy fallback

### DIFF
--- a/components/pages/posts/post/PostMedia.vue
+++ b/components/pages/posts/post/PostMedia.vue
@@ -45,8 +45,10 @@
     () => props.mediaType === 'animated' || (props.mediaType === 'image' && props.mediaSrc.endsWith('.gif'))
   )
 
-  const triedToLoadWithProxy = shallowRef(false)
-  const triedToLoadPosterWithProxy = shallowRef(false)
+  const maxProxyRetryAttempts = 3
+  const mediaProxyRetryAttempts = shallowRef(0)
+  const posterProxyRetryAttempts = shallowRef(0)
+  const proxyRetryNonce = shallowRef(0)
 
   let videoPlayer: FluidPlayerInstance | undefined
 
@@ -270,6 +272,15 @@
     })
   }
 
+  function buildProxyRetryUrl(url: string) {
+    const proxiedUrl = new URL(proxyUrl(url))
+
+    proxyRetryNonce.value++
+    proxiedUrl.searchParams.set('retry', proxyRetryNonce.value.toString())
+
+    return proxiedUrl.toString()
+  }
+
   function startPlayingAnimatedMedia() {
     isAnimatedMediaLoading.value = true
     isAnimatedMediaPlaying.value = true
@@ -291,13 +302,13 @@
       isVideo.value &&
       isPremium.value &&
       //
-      !triedToLoadWithProxy.value
+      mediaProxyRetryAttempts.value < maxProxyRetryAttempts
     ) {
-      localSrc.value = proxyUrl(props.mediaSrc)
+      mediaProxyRetryAttempts.value++
+      localSrc.value = buildProxyRetryUrl(props.mediaSrc)
 
       reloadVideoPlayer(true)
 
-      triedToLoadWithProxy.value = true
       return
     }
 
@@ -315,11 +326,11 @@
         !isAnimatedMediaPlaying.value &&
         target.src === localPosterSrc.value &&
         //
-        !triedToLoadPosterWithProxy.value
+        posterProxyRetryAttempts.value < maxProxyRetryAttempts
       ) {
-        localPosterSrc.value = proxyUrl(props.mediaPosterSrc)
+        posterProxyRetryAttempts.value++
+        localPosterSrc.value = buildProxyRetryUrl(props.mediaPosterSrc)
 
-        triedToLoadPosterWithProxy.value = true
         return
       }
 
@@ -327,11 +338,11 @@
       if (
         isAnimatedMediaPlaying.value &&
         //
-        !triedToLoadWithProxy.value
+        mediaProxyRetryAttempts.value < maxProxyRetryAttempts
       ) {
-        localSrc.value = proxyUrl(props.mediaSrc)
+        mediaProxyRetryAttempts.value++
+        localSrc.value = buildProxyRetryUrl(props.mediaSrc)
 
-        triedToLoadWithProxy.value = true
         return
       }
     }
@@ -341,8 +352,8 @@
 
   function manuallyReloadMedia() {
     // Reset state
-    triedToLoadWithProxy.value = false
-    triedToLoadPosterWithProxy.value = false
+    mediaProxyRetryAttempts.value = 0
+    posterProxyRetryAttempts.value = 0
     error.value = null
 
     // Reload media


### PR DESCRIPTION
## Summary
- retry premium media proxy fallbacks up to 3 times instead of failing after the first proxied attempt
- add a retry nonce to proxied media URLs so repeated fallback attempts do not reuse the same failed request
- reset retry counters on manual reload so users can retry cleanly

## Validation
- `pnpm test` *(fails: missing `@nuxt/test-utils` in repo test dependencies)*
- `pnpm build` *(fails on existing `assets/js/nuxt-image/imgproxy.provider.ts` Buffer/browser build issue)*
- Vue LSP diagnostics unavailable in this environment because `@vue/language-server` is missing

## Feedback
- https://feedback.r34.app/posts/662/dont-load

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved media loading retry mechanism with enhanced control and consistency. Updated internal logic for handling proxy retries across video, image, and animated content loading paths to provide more reliable media loading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->