### PR TITLE
fix: add open-in-new-tab post action

### DIFF
--- a/components/pages/posts/post/PostComponent.vue
+++ b/components/pages/posts/post/PostComponent.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-  import { ChevronDownIcon } from '@heroicons/vue/24/outline'
+  import { ArrowTopRightOnSquareIcon, ChevronDownIcon } from '@heroicons/vue/24/outline'
   import type { IPost } from '~/assets/js/post.dto'
   import Tag from '~/assets/js/tag.dto'
   import { project } from '@/config/project'
@@ -136,6 +136,20 @@
           :mediaName="`${post.domain}-${post.id}`"
           :mediaUrl="post.high_res_file.url ?? post.low_res_file.url ?? (mediaFile.file as string)"
         />
+
+        <NuxtLink
+          v-if="mediaFile.file"
+          :href="mediaFile.file"
+          aria-label="Open media in new tab"
+          class="hover:hover-bg-util focus-visible:focus-outline-util group rounded-md px-1.5 py-1"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          <ArrowTopRightOnSquareIcon
+            aria-hidden="true"
+            class="group-hover:hover-text-util text-base-content h-5 w-5"
+          />
+        </NuxtLink>
 
         <PostSource
           :post-file-url="post.media_type === 'video' ? mediaFile.posterFile : mediaFile.file"

--- a/test/pages/posts.test.ts
+++ b/test/pages/posts.test.ts
@@ -107,10 +107,14 @@ describe('/', async () => {
       // Post
       const firstPost = postsInList.first()
 
+      const openMediaLink = firstPost.getByRole('link', { name: /open media in new tab/i })
+
       // Image
       const firstPostImage = firstPost.locator('img')
 
       expect(await firstPostImage.getAttribute('src')).toBe(mockPostsPage0.data[0].low_res_file.url)
+      expect(await openMediaLink.getAttribute('href')).toBe(mockPostsPage0.data[0].low_res_file.url)
+      expect(await openMediaLink.getAttribute('target')).toBe('_blank')
 
       await firstPost.getByRole('button', { name: /tags/i }).click()
 


### PR DESCRIPTION
## Summary
- add a per-post action that opens the current post media in a new browser tab
- cover the new action with a posts page regression assertion for the rendered link target
- issue: https://feedback.r34.app/posts/607/new-tab-for-every-photo
- board: https://feedback.r34.app/?statuses=open&view=trending

## Validation
- `pnpm install` ✅
- `pnpm test -- test/pages/posts.test.ts` ⚠️ fails because `@nuxt/test-utils` is not installed in this repo's package manifest
- `pnpm build` ⚠️ fails on existing missing file `assets/lib/rule-34-shared-resources/src/util/BooruUtils` imported by `pages/premium/additional-boorus.vue`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an external link button to open media files in a new tab.

* **Tests**
  * Added test coverage for the media open-in-new-tab functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->