### PR TITLE
fix: remeasure virtualized rows after scroll restore

### DIFF
--- a/pages/posts/[domain].vue
+++ b/pages/posts/[domain].vue
@@ -572,10 +572,16 @@
 
   const parentRef = ref<HTMLElement | null>(null)
   const parentOffsetRef = ref(0)
+  let scrollRestoreRemeasureTimeout: ReturnType<typeof setTimeout> | null = null
 
-  onMounted(() => {
-    parentOffsetRef.value = parentRef.value?.offsetTop ?? 0
-  })
+  function clearScrollRestoreRemeasureTimeout() {
+    if (scrollRestoreRemeasureTimeout == null) {
+      return
+    }
+
+    clearTimeout(scrollRestoreRemeasureTimeout)
+    scrollRestoreRemeasureTimeout = null
+  }
 
   const rowVirtualizerOptions = computed(() => {
     return {
@@ -646,6 +652,50 @@
       rowVirtualizer.value.measureElement(el)
     })
   }
+
+  function remeasureAfterScrollRestore() {
+    if (!import.meta.client || window.scrollY === 0) {
+      return
+    }
+
+    clearScrollRestoreRemeasureTimeout()
+
+    nextTick(() => {
+      rowVirtualizer.value.measure()
+
+      requestAnimationFrame(() => {
+        rowVirtualizer.value.measure()
+
+        scrollRestoreRemeasureTimeout = setTimeout(() => {
+          rowVirtualizer.value.measure()
+          scrollRestoreRemeasureTimeout = null
+        }, 250)
+      })
+    })
+  }
+
+  function onPageShow() {
+    remeasureAfterScrollRestore()
+  }
+
+  onMounted(() => {
+    parentOffsetRef.value = parentRef.value?.offsetTop ?? 0
+
+    remeasureAfterScrollRestore()
+    window.addEventListener('pageshow', onPageShow)
+  })
+
+  onBeforeUnmount(() => {
+    clearScrollRestoreRemeasureTimeout()
+    window.removeEventListener('pageshow', onPageShow)
+  })
+
+  watch(
+    () => allRows.value.length,
+    () => {
+      remeasureAfterScrollRestore()
+    }
+  )
 
   /**
    * SEO

--- a/pages/premium/saved-posts/[domain].vue
+++ b/pages/premium/saved-posts/[domain].vue
@@ -474,10 +474,16 @@
 
   const parentRef = ref<HTMLElement | null>(null)
   const parentOffsetRef = ref(0)
+  let scrollRestoreRemeasureTimeout: ReturnType<typeof setTimeout> | null = null
 
-  onMounted(() => {
-    parentOffsetRef.value = parentRef.value?.offsetTop ?? 0
-  })
+  function clearScrollRestoreRemeasureTimeout() {
+    if (scrollRestoreRemeasureTimeout == null) {
+      return
+    }
+
+    clearTimeout(scrollRestoreRemeasureTimeout)
+    scrollRestoreRemeasureTimeout = null
+  }
 
   const rowVirtualizerOptions = computed(() => {
     return {
@@ -548,6 +554,50 @@
       rowVirtualizer.value.measureElement(el)
     })
   }
+
+  function remeasureAfterScrollRestore() {
+    if (!import.meta.client || window.scrollY === 0) {
+      return
+    }
+
+    clearScrollRestoreRemeasureTimeout()
+
+    nextTick(() => {
+      rowVirtualizer.value.measure()
+
+      requestAnimationFrame(() => {
+        rowVirtualizer.value.measure()
+
+        scrollRestoreRemeasureTimeout = setTimeout(() => {
+          rowVirtualizer.value.measure()
+          scrollRestoreRemeasureTimeout = null
+        }, 250)
+      })
+    })
+  }
+
+  function onPageShow() {
+    remeasureAfterScrollRestore()
+  }
+
+  onMounted(() => {
+    parentOffsetRef.value = parentRef.value?.offsetTop ?? 0
+
+    remeasureAfterScrollRestore()
+    window.addEventListener('pageshow', onPageShow)
+  })
+
+  onBeforeUnmount(() => {
+    clearScrollRestoreRemeasureTimeout()
+    window.removeEventListener('pageshow', onPageShow)
+  })
+
+  watch(
+    () => allRows.value.length,
+    () => {
+      remeasureAfterScrollRestore()
+    }
+  )
 
   /**
    * SEO


### PR DESCRIPTION
## Summary
- remeasure virtualized rows after restored scroll positions so already-rendered posts recalculate their height instead of stacking on top of each other
- apply the same recovery path to the premium saved posts page because it shares the same window virtualizer behavior
- keep the fix scoped to scroll-restored/reloaded sessions by remeasuring on mount, pageshow, and list-length changes while the page is already scrolled

## Validation
- `npx prettier --check \"pages/posts/[domain].vue\" \"pages/premium/saved-posts/[domain].vue\"`
- `npm run build` *(fails due to a pre-existing missing file import: `/Users/lume/Projects/Rule-34-App-worktree-47344/assets/lib/rule-34-shared-resources/src/util/BooruUtils` imported by `pages/premium/additional-boorus.vue`)*

## Feedback
- https://feedback.r34.app/posts/178/image-overlapping

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved scroll position restoration and list rendering stability when navigating back to your posts
  * Enhanced visual stability of virtualized post lists during page transitions and data updates
  * Fixed layout flickering that could occur when returning to previously visited pages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->