### PR TITLE
fix: restore ATF and Realbooru in default booru list

### DIFF
--- a/composables/useBooruList.ts
+++ b/composables/useBooruList.ts
@@ -7,9 +7,7 @@ const defaultBooruList: Domain[] = completeBooruList
   .filter((booruObj) => {
     const disabledDomains = [
       //
-      'realbooru.com',
       'konachan.com',
-      'booru.allthefallen.moe',
       'sakugabooru.com'
     ]
 


### PR DESCRIPTION
## Summary
- stop filtering realbooru.com and booru.allthefallen.moe out of the default booru list
- let the shared supported booru definitions decide availability instead of hiding both providers in the app
- feedback post: https://feedback.r34.app/posts/29/atf-and-realbooru-not-working

## Validation
- `pnpm test` *(fails in existing test setup: missing `@nuxt/test-utils` dependency)*
- `pnpm build` *(fails in existing repo/worktree setup: missing `assets/lib/rule-34-shared-resources/src/util/BooruUtils` path)*
- `lsp_diagnostics` *(fails in environment: `typescript-language-server` not installed)*
