### PR TITLE
fix: restore premium media proxy URL

### DIFF
--- a/assets/js/proxy.ts
+++ b/assets/js/proxy.ts
@@ -1,7 +1,7 @@
-import { project } from '@/config/project'
+import { project } from '../../config/project'
 
 export function proxyUrl(url: string, downloadName?: string) {
-  const proxyUrl = new URL(`${project.urls.production.toString()}api/cors-proxy/`)
+  const proxyUrl = new URL('/api/cors-proxy/', project.urls.production)
 
   if (downloadName) {
     proxyUrl.searchParams.set('download', downloadName)

--- a/test/assets/proxy.test.ts
+++ b/test/assets/proxy.test.ts
@@ -1,0 +1,16 @@
+import {describe, expect, it} from 'vitest'
+import {proxyUrl} from '../../assets/js/proxy'
+
+describe('proxyUrl', () => {
+  it('builds a production proxy URL with the expected path and query', () => {
+    expect(proxyUrl('https://example.local/file.jpg')).toBe(
+      'https://r34.app/api/cors-proxy/?q=https%3A%2F%2Fexample.local%2Ffile.jpg'
+    )
+  })
+
+  it('adds an optional download name', () => {
+    expect(proxyUrl('https://example.local/file.jpg', 'sample.jpg')).toBe(
+      'https://r34.app/api/cors-proxy/?download=sample.jpg&q=https%3A%2F%2Fexample.local%2Ffile.jpg'
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- fix the premium media proxy helper to always generate `/api/cors-proxy/` URLs from the production base URL
- add a regression test covering the proxy path and optional download parameter
- targeted validation: `pnpm vitest run test/assets/proxy.test.ts` ✅

## Notes
- `pnpm build` is currently blocked by a pre-existing missing shared-resources import in `pages/premium/additional-boorus.vue`
- TypeScript LSP diagnostics could not run in this environment because `typescript-language-server` is not installed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved proxy URL construction logic for better maintainability.

* **Tests**
  * Added comprehensive test coverage for proxy URL functionality to ensure correct behavior and parameter handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->