### PR TITLE
fix: explain blocklist-hidden results on posts page

### DIFF
--- a/pages/posts/[domain].vue
+++ b/pages/posts/[domain].vue
@@ -386,7 +386,23 @@
       // selectedTags.value.some((tag) => selectedBlockList.value.includes(tag.name)) &&
       selectedBlockList.value.some((blocklistTag) => selectedTags.value.map((tag) => tag.name).includes(blocklistTag))
     ) {
-      throw new Error('One of your selected tags is in the tag block list')
+      return {
+        data: [],
+        meta: {
+          items_count: 0,
+          total_items: 0,
+          current_page: 0,
+          total_pages: 0,
+          items_per_page: 0
+        },
+        links: {
+          self: '',
+          first: '',
+          last: '',
+          prev: '',
+          next: ''
+        }
+      } as IPostPage
     }
 
     if (options.pageParam) {
@@ -568,6 +584,18 @@
         }
       })
     })
+  })
+
+  const isBlockedTagSelected = computed(() => {
+    return (
+      selectedBlockList.value.length > 0 &&
+      selectedBlockList.value.some((blocklistTag) => selectedTags.value.map((tag) => tag.name).includes(blocklistTag))
+    )
+  })
+
+  const hasHiddenPosts = computed(() => {
+    if (!data.value) return false
+    return data.value.pages.some((page) => page.meta.items_count > 0 && page.data.length === 0)
   })
 
   const parentRef = ref<HTMLElement | null>(null)
@@ -958,7 +986,7 @@
       </template>
 
       <!-- Error (initial load only) -->
-      <template v-else-if="isError && !allRows.length">
+      <template v-else-if="isError && !allRows.length && !isBlockedTagSelected && !hasHiddenPosts">
         <PostPageError
           :error="error"
           :on-retry="onRetryClick"
@@ -976,7 +1004,17 @@
 
           <h3 class="text-lg leading-10 font-semibold">No results</h3>
 
-          <span class="w-full overflow-x-auto text-pretty">Try changing the tags or filters</span>
+          <span class="w-full overflow-x-auto text-pretty">
+            <template v-if="isBlockedTagSelected">
+              Your selected tag is in your blocklist
+            </template>
+            <template v-else-if="hasHiddenPosts">
+              Results were hidden by your tag blocklist
+            </template>
+            <template v-else>
+              Try changing the tags or filters
+            </template>
+          </span>
         </div>
       </template>
 


### PR DESCRIPTION
## Summary
- avoid throwing a hard error when a selected tag is blocked; return an empty page response instead
- keep initial error UI for real fetch failures only, and show blocklist-aware empty-state messaging when results are hidden by blocklist rules
- clarify why users see no posts despite tag counts, matching feedback issue 212

## Validation
- pnpm exec nuxi typecheck *(fails due to extensive pre-existing repo-wide type/module issues unrelated to this change)*

Feedback issue: https://feedback.r34.app/p/posts/212/hiding-blocking-tags

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error when selecting blocklisted tags; now displays gracefully with contextual messaging

* **User Experience**
  * Added context-aware messages indicating when content is blocked or hidden by tag filters
  * Improved feedback clarity for empty search results

<!-- end of auto-generated comment: release notes by coderabbit.ai -->