### PR TITLE
feat: support OR keyword in search tags

### DIFF
--- a/assets/js/SearchTagInputHelper.ts
+++ b/assets/js/SearchTagInputHelper.ts
@@ -5,10 +5,10 @@ export function normalizeSearchTagInput(rawValue: string) {
 
   let value = rawValue.trim()
 
-  // Map typed OR separators (including adjacent/repeated "or" tokens) to existing pipe semantics
-  value = value.replace(/\s*(?:\bor\b(?:\s+)?)+\s*/gi, '|')
+  // Collapse one or more OR tokens (case-insensitive) into a comma — the OR-group delimiter
+  value = value.replace(/\s*(?:\bor\b(?:\s+)?)+\s*/gi, ',')
 
-  // Replace spaces inside tags with underscores
+  // Replace remaining spaces (within individual tag names) with underscores
   value = value.replace(/\s/g, '_')
 
   return value

--- a/assets/js/SearchTagInputHelper.ts
+++ b/assets/js/SearchTagInputHelper.ts
@@ -5,8 +5,8 @@ export function normalizeSearchTagInput(rawValue: string) {
 
   let value = rawValue.trim()
 
-  // Map typed OR separators to existing pipe semantics
-  value = value.replace(/\s+or\s+/gi, '|')
+  // Map typed OR separators (including adjacent/repeated "or" tokens) to existing pipe semantics
+  value = value.replace(/\s*(?:\bor\b(?:\s+)?)+\s*/gi, '|')
 
   // Replace spaces inside tags with underscores
   value = value.replace(/\s/g, '_')

--- a/assets/js/SearchTagInputHelper.ts
+++ b/assets/js/SearchTagInputHelper.ts
@@ -1,0 +1,15 @@
+export function normalizeSearchTagInput(rawValue: string) {
+  if (!rawValue) {
+    return ''
+  }
+
+  let value = rawValue.trim()
+
+  // Map typed OR separators to existing pipe semantics
+  value = value.replace(/\s+or\s+/gi, '|')
+
+  // Replace spaces inside tags with underscores
+  value = value.replace(/\s/g, '_')
+
+  return value
+}

--- a/components/pages/home/SimpleSearch.vue
+++ b/components/pages/home/SimpleSearch.vue
@@ -2,6 +2,7 @@
   import { CheckIcon, MagnifyingGlassIcon } from '@heroicons/vue/20/solid'
   import { watchDebounced } from '@vueuse/core'
   import { abbreviateNumber } from 'js-abbreviation-number'
+  import { normalizeSearchTagInput } from '~/assets/js/SearchTagInputHelper'
   import Tag from '~/assets/js/tag.dto'
 
   const props = defineProps<{
@@ -22,14 +23,9 @@
 
   // Change event
   function onComboboxInputChange(event: InputEvent) {
-    let value = (event.target as HTMLInputElement).value
+    const value = (event.target as HTMLInputElement).value
 
-    value = value.trim()
-
-    // Replace empty spaces with underscores
-    value = value.replace(/\s/g, '_')
-
-    searchQuery.value = value
+    searchQuery.value = normalizeSearchTagInput(value)
   }
 
   watchDebounced(searchQuery, (value) => onSearchChange(value), { debounce: 350 })

--- a/components/pages/posts/navigation/search/SearchMenu.vue
+++ b/components/pages/posts/navigation/search/SearchMenu.vue
@@ -4,6 +4,7 @@
   import { watchDebounced } from '@vueuse/core'
   import { abbreviateNumber } from 'js-abbreviation-number'
   import { cloneDeep, unionWith } from 'es-toolkit'
+  import { normalizeSearchTagInput } from '~/assets/js/SearchTagInputHelper'
   import Tag from '~/assets/js/tag.dto'
   import SearchSelect from './SearchSelect.vue'
 
@@ -60,14 +61,9 @@
 
   // Change event
   function onComboboxInputChange(event: InputEvent) {
-    let value = (event.target as HTMLInputElement).value
+    const value = (event.target as HTMLInputElement).value
 
-    value = value.trim()
-
-    // Replace empty spaces with underscores
-    value = value.replace(/\s/g, '_')
-
-    searchQuery.value = value
+    searchQuery.value = normalizeSearchTagInput(value)
   }
 
   watchDebounced(searchQuery, (value) => onSearchChange(value), { debounce: 350 })

--- a/test/assets/search-tag-input-helper.test.ts
+++ b/test/assets/search-tag-input-helper.test.ts
@@ -2,29 +2,29 @@ import { describe, expect, it } from 'vitest'
 import { normalizeSearchTagInput } from '../../assets/js/SearchTagInputHelper'
 
 describe('normalizeSearchTagInput', () => {
-  it('maps typed OR separators to pipes case-insensitively', () => {
-    expect(normalizeSearchTagInput('cat OR dog')).toBe('cat|dog')
-    expect(normalizeSearchTagInput('cat or dog')).toBe('cat|dog')
-    expect(normalizeSearchTagInput('cat Or dog')).toBe('cat|dog')
-    expect(normalizeSearchTagInput('cat oR dog')).toBe('cat|dog')
+  it('maps typed OR separators to commas case-insensitively', () => {
+    expect(normalizeSearchTagInput('cat OR dog')).toBe('cat,dog')
+    expect(normalizeSearchTagInput('cat or dog')).toBe('cat,dog')
+    expect(normalizeSearchTagInput('cat Or dog')).toBe('cat,dog')
+    expect(normalizeSearchTagInput('cat oR dog')).toBe('cat,dog')
   })
 
-  it('maps repeated typed OR separators to existing pipe semantics', () => {
-    expect(normalizeSearchTagInput('cat OR dog or fish')).toBe('cat|dog|fish')
+  it('maps multiple OR separators to commas', () => {
+    expect(normalizeSearchTagInput('cat OR dog or fish')).toBe('cat,dog,fish')
   })
 
   it('preserves existing behavior of converting spaces in tags to underscores', () => {
     expect(normalizeSearchTagInput('black hair')).toBe('black_hair')
-    expect(normalizeSearchTagInput('black hair OR blue eyes')).toBe('black_hair|blue_eyes')
+    expect(normalizeSearchTagInput('black hair OR blue eyes')).toBe('black_hair,blue_eyes')
   })
 
   it('trims surrounding whitespace', () => {
-    expect(normalizeSearchTagInput('  cat OR dog  ')).toBe('cat|dog')
+    expect(normalizeSearchTagInput('  cat OR dog  ')).toBe('cat,dog')
   })
 
-  it('collapses adjacent/repeated OR separators into a single pipe', () => {
-    expect(normalizeSearchTagInput('cat OR OR dog')).toBe('cat|dog')
-    expect(normalizeSearchTagInput('cat or OR or dog')).toBe('cat|dog')
-    expect(normalizeSearchTagInput('cat OR OR OR dog')).toBe('cat|dog')
+  it('collapses adjacent/repeated OR separators into a single comma', () => {
+    expect(normalizeSearchTagInput('cat OR OR dog')).toBe('cat,dog')
+    expect(normalizeSearchTagInput('cat or OR or dog')).toBe('cat,dog')
+    expect(normalizeSearchTagInput('cat OR OR OR dog')).toBe('cat,dog')
   })
 })

--- a/test/assets/search-tag-input-helper.test.ts
+++ b/test/assets/search-tag-input-helper.test.ts
@@ -21,4 +21,10 @@ describe('normalizeSearchTagInput', () => {
   it('trims surrounding whitespace', () => {
     expect(normalizeSearchTagInput('  cat OR dog  ')).toBe('cat|dog')
   })
+
+  it('collapses adjacent/repeated OR separators into a single pipe', () => {
+    expect(normalizeSearchTagInput('cat OR OR dog')).toBe('cat|dog')
+    expect(normalizeSearchTagInput('cat or OR or dog')).toBe('cat|dog')
+    expect(normalizeSearchTagInput('cat OR OR OR dog')).toBe('cat|dog')
+  })
 })

--- a/test/assets/search-tag-input-helper.test.ts
+++ b/test/assets/search-tag-input-helper.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeSearchTagInput } from '../../assets/js/SearchTagInputHelper'
+
+describe('normalizeSearchTagInput', () => {
+  it('maps typed OR separators to pipes case-insensitively', () => {
+    expect(normalizeSearchTagInput('cat OR dog')).toBe('cat|dog')
+    expect(normalizeSearchTagInput('cat or dog')).toBe('cat|dog')
+    expect(normalizeSearchTagInput('cat Or dog')).toBe('cat|dog')
+    expect(normalizeSearchTagInput('cat oR dog')).toBe('cat|dog')
+  })
+
+  it('maps repeated typed OR separators to existing pipe semantics', () => {
+    expect(normalizeSearchTagInput('cat OR dog or fish')).toBe('cat|dog|fish')
+  })
+
+  it('preserves existing behavior of converting spaces in tags to underscores', () => {
+    expect(normalizeSearchTagInput('black hair')).toBe('black_hair')
+    expect(normalizeSearchTagInput('black hair OR blue eyes')).toBe('black_hair|blue_eyes')
+  })
+
+  it('trims surrounding whitespace', () => {
+    expect(normalizeSearchTagInput('  cat OR dog  ')).toBe('cat|dog')
+  })
+})


### PR DESCRIPTION
## Summary

Implements OR search support at the App layer for [Feature: OR search](https://feedback.r34.app/posts/2/feature-or-search) (73 votes).

Users can now type `cat OR dog` (case-insensitive) in the search bar and get real OR semantics from upstream booru sites.

## How it works

`normalizeSearchTagInput` converts user-typed `OR` keywords into a **comma** delimiter, producing a single tag string that encodes the OR group:

- `cat OR dog` → `cat,dog` (one tag element in the URL, encoded as `cat%2Cdog`)
- `black hair OR blue eyes` → `black_hair,blue_eyes`

The comma is used because `|` is already the **AND tag separator** throughout the pipeline (`?tags=tag1|tag2|tag3`). Using `|` for OR groups would cause the existing `.split('|')` logic to destroy OR information before it ever reaches the API.

A comma-delimited OR-group tag passes through the URL, App, and API unchanged as a single array element, and the [Universal-Booru-Wrapper PR](https://github.com/AlejandroAkbal/Universal-Booru-Wrapper/pull/5) translates it to engine-specific OR syntax at query time.

## Changes

- `assets/js/SearchTagInputHelper.ts` — replace `OR` keyword with `,` instead of `|`
- `test/assets/search-tag-input-helper.test.ts` — update all test expectations to use `,`

## Depends on

- Rule-34/API#130 (API pass-through)
- AlejandroAkbal/Universal-Booru-Wrapper#5 (engine OR syntax)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced search input handling with improved normalization of search queries, including proper handling of OR operators, whitespace trimming, and collapsing of multiple separators.
  * Search tag inputs now consistently process spaces and operator variations for better query accuracy.

* **Tests**
  * Added comprehensive test coverage for search input normalization to ensure reliable query processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->