### PR TITLE
fix: add desktop drag scrolling for horizontal rows

### DIFF
--- a/components/pages/home/FeaturedTags.vue
+++ b/components/pages/home/FeaturedTags.vue
@@ -14,6 +14,9 @@
   }>()
 
   const { isPremium } = useUserData()
+  const featuredTagsRef = ref<HTMLOListElement | null>(null)
+
+  useDesktopHorizontalScroll(featuredTagsRef)
 
   const tagsKey = 'preselectedTags:' + `${props.domain}:` + props.tags.map((tag) => tag.media.length).join('-')
 
@@ -32,7 +35,10 @@
 </script>
 
 <template>
-  <ol class="scrollbar-hide grid grid-flow-col gap-4 overflow-x-auto">
+  <ol
+    ref="featuredTagsRef"
+    class="scrollbar-hide grid grid-flow-col gap-4 overflow-x-auto"
+  >
     <template
       v-for="(tag, index) in preselectedTags"
       :key="tag.name"

--- a/components/pages/posts/navigation/search/SearchMenu.vue
+++ b/components/pages/posts/navigation/search/SearchMenu.vue
@@ -33,6 +33,9 @@
   }>()
 
   const isTagCollectionsActive = ref(false)
+  const filtersRowRef = ref<HTMLElement | null>(null)
+
+  useDesktopHorizontalScroll(filtersRowRef)
 
   /**
    * Info: ShallowRef will only update when the entire value changes
@@ -260,7 +263,10 @@
     </HeadlessCombobox>
 
     <!-- Filters -->
-    <section class="scrollbar-hide -mx-5 mt-8 flex gap-4 overflow-x-auto py-1 pr-3 before:w-1 after:w-1">
+    <section
+      ref="filtersRowRef"
+      class="scrollbar-hide -mx-5 mt-8 flex gap-4 overflow-x-auto py-1 pr-3 before:w-1 after:w-1"
+    >
       <!-- -->
 
       <!-- Tag Collections Toggler -->

--- a/composables/useDesktopHorizontalScroll.ts
+++ b/composables/useDesktopHorizontalScroll.ts
@@ -1,0 +1,127 @@
+import { useEventListener } from '@vueuse/core'
+import type { Ref } from 'vue'
+
+const DRAG_THRESHOLD = 4
+
+export function useDesktopHorizontalScroll<T extends HTMLElement>(scrollContainerRef: Ref<T | null>) {
+  let activePointerId: number | null = null
+  let dragStartX = 0
+  let dragStartScrollLeft = 0
+  let didDrag = false
+  let shouldPreventClick = false
+
+  function onWheel(event: WheelEvent) {
+    const scrollContainer = scrollContainerRef.value
+
+    if (!scrollContainer) {
+      return
+    }
+
+    // Preserve touchpad/native horizontal behavior and only map normal mouse wheel.
+    if (event.deltaX !== 0 || event.deltaY === 0 || !isLikelyMouseWheel(event)) {
+      return
+    }
+
+    const maxScrollLeft = scrollContainer.scrollWidth - scrollContainer.clientWidth
+
+    if (maxScrollLeft <= 0) {
+      return
+    }
+
+    const canScrollLeft = scrollContainer.scrollLeft > 0
+    const canScrollRight = scrollContainer.scrollLeft < maxScrollLeft
+
+    if ((event.deltaY < 0 && !canScrollLeft) || (event.deltaY > 0 && !canScrollRight)) {
+      return
+    }
+
+    event.preventDefault()
+
+    scrollContainer.scrollLeft += event.deltaY
+  }
+
+  function onPointerDown(event: PointerEvent) {
+    const scrollContainer = scrollContainerRef.value
+
+    if (!scrollContainer || event.pointerType !== 'mouse' || event.button !== 0) {
+      return
+    }
+
+    const maxScrollLeft = scrollContainer.scrollWidth - scrollContainer.clientWidth
+
+    if (maxScrollLeft <= 0) {
+      return
+    }
+
+    activePointerId = event.pointerId
+    dragStartX = event.clientX
+    dragStartScrollLeft = scrollContainer.scrollLeft
+    didDrag = false
+
+    scrollContainer.setPointerCapture(event.pointerId)
+  }
+
+  function onPointerMove(event: PointerEvent) {
+    const scrollContainer = scrollContainerRef.value
+
+    if (!scrollContainer || activePointerId !== event.pointerId) {
+      return
+    }
+
+    const dragDistance = event.clientX - dragStartX
+
+    if (!didDrag && Math.abs(dragDistance) >= DRAG_THRESHOLD) {
+      didDrag = true
+    }
+
+    if (!didDrag) {
+      return
+    }
+
+    event.preventDefault()
+
+    scrollContainer.scrollLeft = dragStartScrollLeft - dragDistance
+  }
+
+  function endDrag(event: PointerEvent) {
+    const scrollContainer = scrollContainerRef.value
+
+    if (!scrollContainer || activePointerId !== event.pointerId) {
+      return
+    }
+
+    if (scrollContainer.hasPointerCapture(event.pointerId)) {
+      scrollContainer.releasePointerCapture(event.pointerId)
+    }
+
+    shouldPreventClick = didDrag
+    didDrag = false
+    activePointerId = null
+  }
+
+  function onClickCapture(event: MouseEvent) {
+    if (!shouldPreventClick) {
+      return
+    }
+
+    event.preventDefault()
+    event.stopPropagation()
+
+    shouldPreventClick = false
+  }
+
+  useEventListener(scrollContainerRef, 'wheel', onWheel, { passive: false })
+  useEventListener(scrollContainerRef, 'pointerdown', onPointerDown)
+  useEventListener(scrollContainerRef, 'pointermove', onPointerMove)
+  useEventListener(scrollContainerRef, 'pointerup', endDrag)
+  useEventListener(scrollContainerRef, 'pointercancel', endDrag)
+  useEventListener(scrollContainerRef, 'click', onClickCapture, { capture: true })
+}
+
+function isLikelyMouseWheel(event: WheelEvent) {
+  if (event.deltaMode !== WheelEvent.DOM_DELTA_PIXEL) {
+    return true
+  }
+
+  return Number.isInteger(event.deltaY) && Math.abs(event.deltaY) >= 40
+}


### PR DESCRIPTION
## Summary
- add shared desktop-only horizontal scroll behavior for overflowing rows so normal mouse wheel scrolls sideways without breaking touchpad/native horizontal gestures
- enable click-drag scrolling for the featured tags row and search filters row on desktop while suppressing accidental clicks after dragging
- preserve normal page scrolling at row boundaries and keep the change scoped to the two existing horizontal containers

## Validation
- pnpm install
- pnpm exec nuxi typecheck *(fails due to pre-existing repo-wide baseline errors unrelated to this change)*
- pnpm exec nuxi prepare

Feedback issue: https://feedback.r34.app/posts/270/feature-scroll-horizontally-on-desktop-by-click-dragging-or-with-scrolling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Featured tags section now supports horizontal scrolling with drag-to-scroll and mouse wheel input.
  * Search filters now support horizontal scrolling with drag-to-scroll and mouse wheel input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->