### PR TITLE
fix: hide broken media posts in feed

### DIFF
--- a/components/pages/posts/post/PostComponent.vue
+++ b/components/pages/posts/post/PostComponent.vue
@@ -21,7 +21,12 @@
     addTag: [tag: string]
     setTag: [tag: string]
     openTagInNewTab: [tag: string]
+    mediaError: [postId: number]
   }>()
+
+  function onMediaError() {
+    emit('mediaError', props.post.id)
+  }
 
   const currentUrl = useRequestURL()
 
@@ -108,6 +113,7 @@
       :mediaSrcWidth="mediaFile.width"
       :mediaType="post.media_type"
       :postIndex="props.postIndex"
+      @mediaError="onMediaError"
     />
 
     <figcaption>

--- a/components/pages/posts/post/PostMedia.vue
+++ b/components/pages/posts/post/PostMedia.vue
@@ -29,6 +29,10 @@
 
   const props = defineProps<PostMediaProps>()
 
+  const emit = defineEmits<{
+    mediaError: []
+  }>()
+
   const isMainHost = computed(() => import.meta.dev || requestUrl.hostname === project.urls.production.hostname)
 
   const mediaElement = ref<HTMLElement | null>(null)
@@ -337,6 +341,7 @@
     }
 
     error.value = new Error('Error loading media')
+    emit('mediaError')
   }
 
   function manuallyReloadMedia() {

--- a/pages/posts/[domain].vue
+++ b/pages/posts/[domain].vue
@@ -34,23 +34,27 @@
   onMounted(() => {
     const hasLoadedAds = ref(false)
 
-    watch([hasInteracted, isPremium], ([hasInteracted, isPremium]) => {
-      if (hasLoadedAds.value) {
-        return
-      }
+    watch(
+      [hasInteracted, isPremium],
+      ([hasInteracted, isPremium]) => {
+        if (hasLoadedAds.value) {
+          return
+        }
 
-      if (!hasInteracted) {
-        return
-      }
+        if (!hasInteracted) {
+          return
+        }
 
-      if (isPremium) {
-        return
-      }
+        if (isPremium) {
+          return
+        }
 
-      hasLoadedAds.value = true
+        hasLoadedAds.value = true
 
-      useAdvertisements()
-    }, { immediate: true })
+        useAdvertisements()
+      },
+      { immediate: true }
+    )
   })
 
   /**
@@ -375,6 +379,34 @@
     window.location.reload()
   }
 
+  const hiddenPostMediaErrorKeys = ref<string[]>([])
+
+  const hiddenPostMediaErrorScopeKey = computed(() => {
+    return JSON.stringify({
+      domain: selectedBooru.value.domain,
+      tags: selectedTags.value.map((tag) => tag.name),
+      filters: selectedFilters.value
+    })
+  })
+
+  function getPostMediaErrorKey(postId: number) {
+    return `${selectedBooru.value.domain}-${postId}`
+  }
+
+  function onPostMediaError(postId: number) {
+    const postMediaErrorKey = getPostMediaErrorKey(postId)
+
+    if (hiddenPostMediaErrorKeys.value.includes(postMediaErrorKey)) {
+      return
+    }
+
+    hiddenPostMediaErrorKeys.value.push(postMediaErrorKey)
+  }
+
+  watch(hiddenPostMediaErrorScopeKey, () => {
+    hiddenPostMediaErrorKeys.value = []
+  })
+
   /**
    * Data fetching
    */
@@ -554,6 +586,10 @@
       //
 
       return page.data.flatMap((post, index) => {
+        if (hiddenPostMediaErrorKeys.value.includes(getPostMediaErrorKey(post.id))) {
+          return []
+        }
+
         //
 
         return {
@@ -1059,6 +1095,7 @@
                   :postIndex="virtualRow.index"
                   :selectedTags="selectedTags"
                   @addTag="onPostAddTag"
+                  @mediaError="onPostMediaError"
                   @openTagInNewTab="onPostOpenTagInNewTab"
                   @setTag="onPostSetTag"
                 />

--- a/test/pages/posts.test.ts
+++ b/test/pages/posts.test.ts
@@ -1,12 +1,12 @@
-import {describe, expect, it} from 'vitest'
-import {createPage, setup, url} from '@nuxt/test-utils'
+import { describe, expect, it } from 'vitest'
+import { createPage, setup, url } from '@nuxt/test-utils'
 import {
   mockPostsPage0,
   mockPostsPage1,
   mockPostsPageWithOfflineMedia,
   mockPostsPageWithoutResults
 } from './posts.mock-data'
-import {defaultSetupConfig} from '../helper'
+import { defaultSetupConfig } from '../helper'
 
 describe('/', async () => {
   await setup(defaultSetupConfig)
@@ -127,7 +127,7 @@ describe('/', async () => {
       throw new Error('Not implemented')
     })
 
-    it('renders warning when media failed to load', async () => {
+    it('hides post when media failed to load in feed', async () => {
       // Arrange
       const page = await createPage()
 
@@ -151,23 +151,16 @@ describe('/', async () => {
       await Promise.all([
         page.goto(url('/posts/safebooru.org')),
         page.waitForResponse('**/posts?baseEndpoint=*'),
-
-        await page.waitForRequest('**/example.local/**')
+        page.waitForRequest('**/example.local/**')
       ])
 
       // Assert
 
-      // Expect 1 post
-      expect(
-        //
-        await page.getByTestId('posts-list').locator('li').count()
-      ).toBe(1)
+      // Expect post to be hidden after media fails
+      expect(await page.getByRole('heading', { name: /no results/i }).isVisible()).toBe(true)
 
-      // Expect post to have warning
-      expect(
-        //
-        await page.getByTestId('posts-list').locator('li').first().textContent()
-      ).toContain('Error loading media')
+      // Expect no media error placeholder to remain in feed
+      expect(await page.getByText('Error loading media').count()).toBe(0)
     })
   })
 


### PR DESCRIPTION
## Summary
- hide feed posts after their media definitively fails to load instead of leaving broken placeholders in the results list
- bubble media load failures from `PostMedia` through `PostComponent` so the posts page can filter failed items per search context
- update the posts page regression test to cover hiding broken feed items for feedback issue https://feedback.r34.app/posts/10/feature-block-or-hide-unloadable-posts

## Validation
- `pnpm build` *(fails due to pre-existing `Buffer` export issue in `assets/js/nuxt-image/imgproxy.provider.ts` under the current environment)*
- `pnpm test test/pages/posts.test.ts -t \"hides post when media failed to load in feed\"` *(fails because `@nuxt/test-utils` is not installed in this repo environment)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Posts with media loading failures are now automatically hidden from the feed for a cleaner browsing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->