### PR TITLE
feat: add video-only posts filter

### DIFF
--- a/pages/posts/[domain].vue
+++ b/pages/posts/[domain].vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-  import { Bars3BottomRightIcon, EyeIcon, MagnifyingGlassIcon, StarIcon } from '@heroicons/vue/24/outline'
+  import { Bars3BottomRightIcon, EyeIcon, MagnifyingGlassIcon, PhotoIcon, StarIcon } from '@heroicons/vue/24/outline'
   import { ArrowPathIcon, QuestionMarkCircleIcon } from '@heroicons/vue/24/solid'
   import { useInfiniteQuery } from '@tanstack/vue-query'
   import { useWindowVirtualizer } from '@tanstack/vue-virtual'
@@ -99,6 +99,7 @@
     // TODO: Validate
 
     return {
+      type: route.query.filter?.type ?? undefined,
       rating: route.query.filter?.rating ?? undefined,
       sort: route.query.filter?.sort ?? undefined,
       score: route.query.filter?.score ?? undefined
@@ -106,6 +107,15 @@
   })
 
   const filterConfig = {
+    type: {
+      type: 'select' as const,
+      label: 'Type',
+      icon: PhotoIcon,
+      options: [
+        { label: 'Type', value: undefined },
+        { label: 'Video', value: 'video' }
+      ]
+    },
     sort: {
       type: 'select' as const,
       label: 'Sort',
@@ -485,6 +495,10 @@
           return false
         }
 
+        if (selectedFilters.value.type && post.media_type !== selectedFilters.value.type) {
+          return false
+        }
+
         // Delete all posts that have a blocklisted tag
         if (selectedBlockList.value.length > 0) {
           const postTags = post.tags.meta.concat(
@@ -666,6 +680,10 @@
     }
 
     // Filters
+    if (selectedFilters.value.type) {
+      title += `, ${selectedFilters.value.type} only`
+    }
+
     if (selectedFilters.value.rating) {
       title += `, rated ${selectedFilters.value.rating}`
     }
@@ -737,6 +755,10 @@
     let description = `Stream and download ${tagsTitle ?? 'various'} Hentai porn videos, GIFs and images`
 
     // Filters
+    if (selectedFilters.value.type) {
+      description += `, ${selectedFilters.value.type} only`
+    }
+
     if (selectedFilters.value.rating) {
       description += `, rated ${selectedFilters.value.rating}`
     }

--- a/test/assets/router-helper.test.ts
+++ b/test/assets/router-helper.test.ts
@@ -45,4 +45,21 @@ describe('generatePostsRoute', () => {
       'panty_&_stocking_with_garterbelt|rating:safe'
     )
   })
+
+  it('keeps filter values in query object', () => {
+    const route = generatePostsRoute('/posts', 'safebooru.org', undefined, undefined, {
+      type: 'video',
+      sort: 'score'
+    })
+
+    expect(route).toMatchObject({
+      path: '/posts/safebooru.org',
+      query: {
+        filter: {
+          type: 'video',
+          sort: 'score'
+        }
+      }
+    })
+  })
 })


### PR DESCRIPTION
## Summary
- add a Type filter option to the public posts search menu so users can narrow results to videos only
- keep the filter in the posts route query and reflect it in page metadata for shareable filtered searches
- cover filter query persistence with a router helper regression test

## Validation
- pnpm install
- git submodule update --init --recursive
- pnpm exec vitest run test/assets/router-helper.test.ts
- pnpm exec nuxi typecheck *(fails due to pre-existing repo-wide issues, including missing @vue/language-core and unrelated TypeScript errors)*

## Feedback
- https://feedback.r34.app/posts/214/filter-options

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new "Type" filter to the posts page, enabling users to filter by media type (photo or video)
  * Page titles and SEO descriptions now automatically reflect the active type filter selection

* **Tests**
  * Added test coverage for route filter persistence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->