### PR TITLE
fix: autoplay videos from media settings

### DIFF
--- a/components/pages/posts/post/PostMedia.vue
+++ b/components/pages/posts/post/PostMedia.vue
@@ -62,6 +62,7 @@
     switch (true) {
       case isVideo.value:
         createVideoPlayer()
+
         break
 
       case isAnimatedMedia.value:
@@ -114,6 +115,10 @@
         primaryColor: 'rgba(0, 0, 0, 0.7)',
 
         fillToContainer: true,
+
+        autoPlay: autoplayAnimatedMedia.value,
+
+        mute: autoplayAnimatedMedia.value,
 
         preload: 'none',
 

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -136,9 +136,11 @@
         <!-- autoplayAnimatedMedia -->
         <li>
           <SettingSwitch v-model="autoplayAnimatedMedia">
-            <template #name> Autoplay GIFs</template>
+            <template #name> Autoplay GIFs & videos</template>
 
-            <template #description> Automatically play animated GIFs without requiring a click </template>
+            <template #description>
+              Automatically play animated GIFs and start videos muted without requiring a click
+            </template>
           </SettingSwitch>
         </li>
 

--- a/test/pages/settings.test.ts
+++ b/test/pages/settings.test.ts
@@ -11,5 +11,6 @@ describe('/settings', async () => {
     await page.waitForSelector('h1')
 
     expect(await page.textContent('h1')).toBe('Settings')
+    expect(await page.textContent('main')).toContain('Autoplay GIFs & videos')
   })
 })


### PR DESCRIPTION
## Summary
- extend the existing autoplay animated media setting to videos using Fluid Player's built-in autoplay and muted playback options
- update the settings copy so users know the toggle now starts videos muted
- add a settings page assertion covering the new label text

## Validation
- pnpm exec prettier --write \"components/pages/posts/post/PostMedia.vue\" \"pages/settings.vue\" \"test/pages/settings.test.ts\"
- pnpm exec prettier --check \"components/pages/posts/post/PostMedia.vue\" \"pages/settings.vue\" \"test/pages/settings.test.ts\"
- pnpm exec vitest run \"test/pages/settings.test.ts\" *(fails: Cannot find package '@nuxt/test-utils' imported from test/pages/settings.test.ts; pre-existing environment issue)*
- pnpm exec nuxi typecheck *(fails with many pre-existing project type errors, including missing @nuxt/test-utils and unrelated app-wide typing issues)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded autoplay support to cover both animated GIFs and videos. When enabled, videos will automatically start muted, providing a smoother browsing experience without unexpected audio playback.

* **Documentation**
  * Updated the autoplay settings label and description to reflect the new capability for both GIFs and videos, with clarification that videos play muted automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->