### PR TITLE
feat: add tag collection shortcut from post tags

### DIFF
--- a/components/pages/posts/post/PostTag.vue
+++ b/components/pages/posts/post/PostTag.vue
@@ -1,20 +1,21 @@
 <script lang="ts" setup>
-import {
-  ArrowTopRightOnSquareIcon,
-  DocumentDuplicateIcon,
-  MagnifyingGlassIcon,
-  MinusIcon,
-  NoSymbolIcon,
-  PlusIcon,
-  ShieldExclamationIcon
-} from '@heroicons/vue/24/outline'
-import { useClipboard } from '@vueuse/core'
-import { toast } from 'vue-sonner'
-import { flip, offset, shift, useFloating } from '@floating-ui/vue'
-import type Tag from '~/assets/js/tag.dto'
-import { blockListOptions } from '~/composables/useBlockLists'
+  import {
+    ArrowTopRightOnSquareIcon,
+    DocumentDuplicateIcon,
+    MagnifyingGlassIcon,
+    MinusIcon,
+    NoSymbolIcon,
+    PlusIcon,
+    ShieldExclamationIcon
+  } from '@heroicons/vue/24/outline'
+  import { useClipboard } from '@vueuse/core'
+  import { toast } from 'vue-sonner'
+  import { flip, offset, shift, useFloating } from '@floating-ui/vue'
+  import type Tag from '~/assets/js/tag.dto'
+  import { TagCollection } from '~/assets/js/tagCollection.dto'
+  import { blockListOptions } from '~/composables/useBlockLists'
 
-const props = defineProps<{
+  const props = defineProps<{
     tag: Tag
     selectedTags: Tag[]
   }>()
@@ -27,6 +28,7 @@ const props = defineProps<{
 
   const { isPremium } = useUserData()
   const { customBlockList, selectedList } = useBlockLists()
+  const { tagCollections } = useTagCollections()
   const { copy } = useClipboard()
 
   const referenceEl = ref<HTMLElement>()
@@ -74,6 +76,43 @@ const props = defineProps<{
         duration: 10000 // 10 seconds
       })
     }
+  }
+
+  function addTagToCollection(tag: Tag) {
+    if (!isPremium.value) {
+      const { open: promptPremium, currentIndex } = usePremiumDialog()
+      currentIndex.value = 6
+      promptPremium.value = true
+      return
+    }
+
+    const name = prompt('Enter a tag collection name')?.trim()
+
+    if (!name) {
+      return
+    }
+
+    const existingTagCollection = tagCollections.value.find((tagCollection) => tagCollection.name === name)
+
+    if (existingTagCollection) {
+      if (existingTagCollection.tags.includes(tag.name)) {
+        toast.info('Tag is already in this collection')
+        return
+      }
+
+      existingTagCollection.tags.push(tag.name)
+      toast.success('Tag added to collection')
+      return
+    }
+
+    tagCollections.value.push(
+      new TagCollection({
+        name,
+        tags: [tag.name]
+      })
+    )
+
+    toast.success('Tag collection created')
   }
 </script>
 
@@ -184,6 +223,25 @@ const props = defineProps<{
                 />
 
                 Copy tag
+              </button>
+            </HeadlessMenuItem>
+          </div>
+
+          <!-- Tag Collection Management (Premium only) -->
+          <div class="py-1">
+            <HeadlessMenuItem v-slot="{ active }">
+              <button
+                :class="[active ? 'bg-base-0/20 text-base-content-highlight' : 'text-base-content']"
+                class="group flex w-full items-center px-2.5 py-1 text-sm"
+                type="button"
+                @click="addTagToCollection(tag)"
+              >
+                <PlusIcon
+                  aria-hidden="true"
+                  class="mr-3 h-4 w-4 shrink-0 rounded-sm"
+                />
+
+                Add to tag collection
               </button>
             </HeadlessMenuItem>
           </div>


### PR DESCRIPTION
## Summary
- add an "Add to tag collection" action to the post tag context menu so premium users can save a tag directly from a post
- reuse the existing tag collections state, create collections on demand, and avoid duplicate tag entries
- preserve the current premium upsell flow for non-premium users

## Validation
- `pnpm exec vitest run test/pages/posts.test.ts` *(fails: missing existing `@nuxt/test-utils` dependency in repo test setup)*
- `pnpm exec nuxi typecheck` *(fails with many pre-existing repo type errors and missing-module issues unrelated to this change)*

## Feedback
- https://feedback.r34.app/posts/24/feature-press-tag-to-allow-adding-to-tag-group

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Tags can now be organized into custom collections
  * New "Add to tag collection" action available in tag menus
  * Built-in duplicate detection prevents adding the same tag multiple times
  * Premium-only feature includes intuitive naming and collection management
  * Toast notifications confirm successful updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->