### PR TITLE
refactor: simplify posts route tag handling

### DIFF
--- a/assets/js/RouterHelper.ts
+++ b/assets/js/RouterHelper.ts
@@ -22,7 +22,7 @@ export function generatePostsRoute(
   }
 
   if (tags != null && Array.isArray(tags) && tags.length) {
-    route.query.tags = tags.map((tag) => encodeURIComponent(tag.name)).join('|')
+    route.query.tags = tags.map((tag) => tag.name).join('|')
   }
 
   // Check if object keys are not undefined

--- a/pages/posts/[domain].vue
+++ b/pages/posts/[domain].vue
@@ -81,7 +81,6 @@
 
     return tags
       .split('|')
-      .map((tag) => decodeURIComponent(tag))
       .map((tag) => new Tag({ name: tag }).toJSON())
   })
 

--- a/pages/premium/saved-posts/[domain].vue
+++ b/pages/premium/saved-posts/[domain].vue
@@ -85,7 +85,6 @@
 
     return tags
       .split('|')
-      .map((tag) => decodeURIComponent(tag))
       .map((tag) => new Tag({ name: tag }).toJSON())
   })
 

--- a/test/assets/router-helper.test.ts
+++ b/test/assets/router-helper.test.ts
@@ -3,7 +3,7 @@ import {generatePostsRoute} from '../../assets/js/RouterHelper'
 import Tag from '../../assets/js/tag.dto'
 
 describe('generatePostsRoute', () => {
-  it('encodes ampersands in tag query values', () => {
+  it('keeps raw tag values in route query objects', () => {
     const route = generatePostsRoute(
       '/posts',
       'safebooru.org',
@@ -15,14 +15,13 @@ describe('generatePostsRoute', () => {
     expect(route).toMatchObject({
       path: '/posts/safebooru.org',
       query: {
-        tags: 'panty_%26_stocking_with_garterbelt'
+        tags: 'panty_&_stocking_with_garterbelt'
       }
     })
-
-    expect(decodeURIComponent(String(route.query?.tags))).toBe('panty_&_stocking_with_garterbelt')
+    expect(String(route.query?.tags)).toBe('panty_&_stocking_with_garterbelt')
   })
 
-  it('encodes multiple tags joined by pipes when one contains an ampersand', () => {
+  it('keeps multiple tag and filter values raw before router serialization', () => {
     const route = generatePostsRoute(
       '/posts',
       'safebooru.org',
@@ -37,12 +36,10 @@ describe('generatePostsRoute', () => {
     expect(route).toMatchObject({
       path: '/posts/safebooru.org',
       query: {
-        tags: 'panty_%26_stocking_with_garterbelt|rating%3Asafe'
+        tags: 'panty_&_stocking_with_garterbelt|rating:safe'
       }
     })
 
-    expect(decodeURIComponent(String(route.query?.tags))).toBe(
-      'panty_&_stocking_with_garterbelt|rating:safe'
-    )
+    expect(String(route.query?.tags)).toBe('panty_&_stocking_with_garterbelt|rating:safe')
   })
 })


### PR DESCRIPTION
## Summary
- remove redundant manual tag encode/decode in posts route handling and rely on the existing qs router query serializer/parser
- keep the `|`-joined tag format while simplifying both posts pages and RouterHelper behavior
- update router-helper coverage to assert raw query-object values instead of double-handled encoded strings

## Validation
- File-level readback confirmed the intended changes in RouterHelper, both posts pages, and router-helper tests
- Runtime test execution in the isolated worktree was blocked because the fresh worktree lacks linked Vitest binaries and generated `.nuxt/tsconfig.json`
- Prior targeted validation for this exact change passed before isolation via `pnpm exec vitest run test/assets/router-helper.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated tag parameter handling in URLs to display special characters in raw format instead of percent-encoded sequences.

* **Tests**
  * Updated test expectations to align with updated tag parameter formatting in URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->