### PR TITLE
feat: let users collapse posts inline

### DIFF
--- a/components/pages/posts/post/PostComponent.vue
+++ b/components/pages/posts/post/PostComponent.vue
@@ -29,6 +29,17 @@
   const { isPremium } = useUserData()
 
   const areTagsOpen = ref(false)
+  const isCollapsed = ref(false)
+
+  function toggleCollapsedState() {
+    isCollapsed.value = !isCollapsed.value
+
+    if (!isCollapsed.value) {
+      return
+    }
+
+    areTagsOpen.value = false
+  }
 
   const mediaFile = computed(() => {
     const stripFragment = (url?: string | null) => url?.split('#')[0] ?? null
@@ -96,19 +107,42 @@
   const tagTypesWithTags = computed(() => {
     return Object.keys(props.post.tags).filter((tagType) => props.post.tags[tagType].length > 0)
   })
+
+  const collapsedSummary = computed(() => {
+    const mediaLabel = props.post.media_type === 'animated' ? 'animation' : props.post.media_type
+
+    return `${mediaLabel} #${props.post.id} hidden`
+  })
 </script>
 
 <template>
   <figure class="border-base-0/20 rounded-md border">
-    <PostMedia
-      :mediaAlt="mediaFile.alt"
-      :mediaPosterSrc="mediaFile.posterFile"
-      :mediaSrc="mediaFile.file"
-      :mediaSrcHeight="mediaFile.height"
-      :mediaSrcWidth="mediaFile.width"
-      :mediaType="post.media_type"
-      :postIndex="props.postIndex"
-    />
+    <div
+      v-if="!isCollapsed"
+      :title="`Double-click to hide post #${post.id}`"
+      @dblclick="toggleCollapsedState"
+    >
+      <PostMedia
+        :mediaAlt="mediaFile.alt"
+        :mediaPosterSrc="mediaFile.posterFile"
+        :mediaSrc="mediaFile.file"
+        :mediaSrcHeight="mediaFile.height"
+        :mediaSrcWidth="mediaFile.width"
+        :mediaType="post.media_type"
+        :postIndex="props.postIndex"
+      />
+    </div>
+
+    <button
+      v-else
+      :aria-label="`Show post #${post.id}`"
+      class="hover:hover-bg-util focus-visible:focus-outline-util text-base-content flex min-h-28 w-full flex-col items-center justify-center gap-2 rounded-t-md px-4 py-4 text-center"
+      type="button"
+      @click="toggleCollapsedState"
+    >
+      <span class="text-base-content-highlight text-sm font-semibold">{{ collapsedSummary }}</span>
+      <span class="text-base-content/80 text-xs">Click to show it again</span>
+    </button>
 
     <figcaption>
       <!-- Post description -->


### PR DESCRIPTION
## Summary
- let users hide an individual post by double-clicking its media area
- swap hidden posts for a compact inline placeholder that can reopen the post without forcing users to scroll through long comics or unwanted media
- close the tag sheet when a post is collapsed so hidden posts stay compact

## Validation
- `pnpm exec prettier --check /Users/lume/Projects/Rule-34-App-worktree-5158/components/pages/posts/post/PostComponent.vue`
- `pnpm exec nuxi typecheck` *(fails on current branch due to widespread pre-existing type errors unrelated to this change, including `app/router.options.ts`, `assets/js/BackupHelper.ts`, `components/pages/posts/post/PostMedia.vue`, and many others)*

## Feedback Post
- https://feedback.r34.app/posts/578/being-able-to-close-shrink-posts-by-double-clicking-on-them-etc