### PR TITLE
fix: sync vue virtual measurements after updates

### DIFF
--- a/pages/posts/[domain].vue
+++ b/pages/posts/[domain].vue
@@ -601,6 +601,7 @@
   const virtualRows = computed(() => rowVirtualizer.value.getVirtualItems())
 
   const totalSize = computed(() => rowVirtualizer.value.getTotalSize())
+  const virtualItemEls: Ref<(HTMLElement | null)[]> = shallowRef([])
 
   // Next page loader
   watchEffect(() => {
@@ -636,8 +637,10 @@
   })
 
   // FIX: Remove when this issue is fixed - https://github.com/TanStack/virtual/issues/619#issuecomment-1969516091
-  const measureElement = (el) => {
-    nextTick(() => {
+  const measureAll = () => {
+    rowVirtualizer.value.measureElement(null)
+
+    virtualItemEls.value.forEach((el) => {
       if (!el) {
         return
       }
@@ -645,6 +648,14 @@
       rowVirtualizer.value.measureElement(el)
     })
   }
+
+  onMounted(() => {
+    measureAll()
+  })
+
+  onUpdated(() => {
+    measureAll()
+  })
 
   /**
    * SEO
@@ -1009,7 +1020,7 @@
             <li
               v-for="virtualRow in virtualRows"
               :key="virtualRow.key"
-              :ref="measureElement"
+              ref="virtualItemEls"
               :data-index="virtualRow.index"
             >
               <!-- Next Pagination -->

--- a/pages/premium/saved-posts/[domain].vue
+++ b/pages/premium/saved-posts/[domain].vue
@@ -503,6 +503,7 @@
   const virtualRows = computed(() => rowVirtualizer.value.getVirtualItems())
 
   const totalSize = computed(() => rowVirtualizer.value.getTotalSize())
+  const virtualItemEls: Ref<(HTMLElement | null)[]> = shallowRef([])
 
   // Next page loader
   watchEffect(() => {
@@ -538,8 +539,10 @@
   })
 
   // FIX: Remove when this issue is fixed - https://github.com/TanStack/virtual/issues/619#issuecomment-1969516091
-  const measureElement = (el) => {
-    nextTick(() => {
+  const measureAll = () => {
+    rowVirtualizer.value.measureElement(null)
+
+    virtualItemEls.value.forEach((el) => {
       if (!el) {
         return
       }
@@ -547,6 +550,14 @@
       rowVirtualizer.value.measureElement(el)
     })
   }
+
+  onMounted(() => {
+    measureAll()
+  })
+
+  onUpdated(() => {
+    measureAll()
+  })
 
   /**
    * SEO
@@ -805,7 +816,7 @@
             <li
               v-for="virtualRow in virtualRows"
               :key="virtualRow.key"
-              :ref="measureElement"
+              ref="virtualItemEls"
               :data-index="virtualRow.index"
             >
               <!-- Next Pagination -->


### PR DESCRIPTION
## Summary
- update the posts and saved-posts window virtualizers to batch dynamic row measurements after Vue updates
- replace the old callback-ref plus nextTick workaround with the upstream TanStack ref-array + measureAll pattern used for the scroll-up bug family
- clear stale measurements before remeasuring visible rows so dynamic-height scrolling stays stable when moving upward

## Validation
- `pnpm install` ✅
- `pnpm exec nuxi typecheck` ⚠️ fails due to existing repo-wide type issues and missing modules unrelated to this change
- `pnpm test` ⚠️ fails because existing test setup is missing `@nuxt/test-utils`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved virtual list measurement logic in post listing pages to ensure accurate rendering of all items during scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->