### PR TITLE
fix: redirect unauthorized premium booru searches

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -10,14 +10,13 @@
     const url = 'https://' + project.urls.production.hostname + route.fullPath
 
     const parsedUrl = new URL(url)
+    const canonicalIgnoredParams = new Set(['page', 'cursor', 'source_booru'])
 
-    // Remove query params: page, cursor, and tracking params
-    parsedUrl.searchParams.delete('page')
-    parsedUrl.searchParams.delete('cursor')
-    parsedUrl.searchParams.delete('source_booru')
-
+    // Keep canonical URLs focused on content-defining params only.
+    // Redirect attribution params (utm_* and source_booru) are intentionally removed so
+    // premium-redirect landings don't create duplicate canonicals for the same page.
     for (const key of [...parsedUrl.searchParams.keys()]) {
-      if (key.startsWith('utm_')) {
+      if (canonicalIgnoredParams.has(key) || key.startsWith('utm_')) {
         parsedUrl.searchParams.delete(key)
       }
     }

--- a/app.vue
+++ b/app.vue
@@ -11,9 +11,16 @@
 
     const parsedUrl = new URL(url)
 
-    // Remove query params: page or cursor
+    // Remove query params: page, cursor, and tracking params
     parsedUrl.searchParams.delete('page')
     parsedUrl.searchParams.delete('cursor')
+    parsedUrl.searchParams.delete('source_booru')
+
+    for (const key of [...parsedUrl.searchParams.keys()]) {
+      if (key.startsWith('utm_')) {
+        parsedUrl.searchParams.delete(key)
+      }
+    }
 
     return parsedUrl.href
   })

--- a/assets/js/RouterHelper.ts
+++ b/assets/js/RouterHelper.ts
@@ -1,6 +1,8 @@
 import Tag from './tag.dto'
 import type { RouteLocationRaw } from 'vue-router'
 
+export const fallbackBooruDomain = 'rule34.xxx'
+
 export function generatePostsRoute(
   path: string = '/posts',
   domain?: string | undefined | null,
@@ -31,6 +33,20 @@ export function generatePostsRoute(
   }
 
   return route
+}
+
+export function getSingleQueryValue(value: string | string[] | null | (string | null)[] | undefined) {
+  if (Array.isArray(value)) {
+    const firstValue = value[0]
+
+    return firstValue ?? undefined
+  }
+
+  if (value === null || value === undefined) {
+    return undefined
+  }
+
+  return value
 }
 
 function isObjectEmpty(obj) {

--- a/pages/posts/[domain].vue
+++ b/pages/posts/[domain].vue
@@ -74,6 +74,8 @@
     )
   })
 
+  // Reopen the existing premium upsell when a non-premium user lands here
+  // via redirect from a premium-only booru to the fallback booru route.
   onMounted(() => {
     if (isPremium.value) {
       return
@@ -885,18 +887,20 @@
         }
 
         const tags = getSingleQueryValue(to.query.tags)
+        const redirectQuery = {
+          ...(tags ? { tags } : {}),
+          utm_source: 'internal',
+          utm_medium: 'unauthorized-booru-redirect',
+          utm_campaign: 'additional-boorus',
+          utm_content: domain,
+          // Used after landing to reopen the existing premium upsell modal.
+          source_booru: domain
+        }
 
         return navigateTo(
           {
             path: `/posts/${fallbackBooruDomain}`,
-            query: {
-              ...(tags ? { tags } : {}),
-              utm_source: 'internal',
-              utm_medium: 'unauthorized-booru-redirect',
-              utm_campaign: 'additional-boorus',
-              utm_content: domain,
-              source_booru: domain
-            }
+            query: redirectQuery
           },
           {
             redirectCode: 302

--- a/pages/posts/[domain].vue
+++ b/pages/posts/[domain].vue
@@ -28,29 +28,71 @@
 
   const { selectedDomainFromStorage } = useSelectedDomainFromStorage()
 
+  const fallbackBooruDomain = 'rule34.xxx'
+  const additionalBoorusPremiumSlideIndex = 4
+
+  function getSingleQueryValue(value: string | string[] | null | (string | null)[] | undefined) {
+    if (Array.isArray(value)) {
+      const firstValue = value[0]
+
+      return firstValue ?? undefined
+    }
+
+    if (value === null || value === undefined) {
+      return undefined
+    }
+
+    return value
+  }
+
   /**
    * Show ads for non-premium users
    */
   onMounted(() => {
     const hasLoadedAds = ref(false)
 
-    watch([hasInteracted, isPremium], ([hasInteracted, isPremium]) => {
-      if (hasLoadedAds.value) {
-        return
-      }
+    watch(
+      [hasInteracted, isPremium],
+      ([hasInteracted, isPremium]) => {
+        if (hasLoadedAds.value) {
+          return
+        }
 
-      if (!hasInteracted) {
-        return
-      }
+        if (!hasInteracted) {
+          return
+        }
 
-      if (isPremium) {
-        return
-      }
+        if (isPremium) {
+          return
+        }
 
-      hasLoadedAds.value = true
+        hasLoadedAds.value = true
 
-      useAdvertisements()
-    }, { immediate: true })
+        useAdvertisements()
+      },
+      { immediate: true }
+    )
+  })
+
+  onMounted(() => {
+    if (isPremium.value) {
+      return
+    }
+
+    if (selectedBooru.value.domain !== fallbackBooruDomain) {
+      return
+    }
+
+    const sourceBooru = getSingleQueryValue(route.query.source_booru)
+
+    if (!sourceBooru) {
+      return
+    }
+
+    const { open: promptPremium, currentIndex } = usePremiumDialog()
+
+    currentIndex.value = additionalBoorusPremiumSlideIndex
+    promptPremium.value = true
   })
 
   /**
@@ -79,9 +121,7 @@
       return []
     }
 
-    return tags
-      .split('|')
-      .map((tag) => new Tag({ name: tag }).toJSON())
+    return tags.split('|').map((tag) => new Tag({ name: tag }).toJSON())
   })
 
   const selectedPage = computed(() => {
@@ -823,6 +863,48 @@
   ])
 
   definePageMeta({
+    middleware: [
+      (to) => {
+        const { booruList } = useBooruList()
+        const { isPremium } = useUserData()
+
+        if (isPremium.value) {
+          return
+        }
+
+        const domain = Array.isArray(to.params.domain) ? to.params.domain[0] : to.params.domain
+
+        if (!domain || domain === fallbackBooruDomain) {
+          return
+        }
+
+        const booru = booruList.value.find((booru) => booru.domain === domain)
+
+        if (!booru?.isPremium) {
+          return
+        }
+
+        const tags = getSingleQueryValue(to.query.tags)
+
+        return navigateTo(
+          {
+            path: `/posts/${fallbackBooruDomain}`,
+            query: {
+              ...(tags ? { tags } : {}),
+              utm_source: 'internal',
+              utm_medium: 'unauthorized-booru-redirect',
+              utm_campaign: 'additional-boorus',
+              utm_content: domain,
+              source_booru: domain
+            }
+          },
+          {
+            redirectCode: 302
+          }
+        )
+      }
+    ],
+
     validate: async (route) => {
       const { booruList } = useBooruList()
 
@@ -832,15 +914,6 @@
 
       if (!booru) {
         return false
-      }
-
-      const { isPremium } = useUserData()
-
-      if (!isPremium.value && booru.isPremium) {
-        return {
-          status: 401,
-          statusText: 'Unauthorized, please login to view this page'
-        }
       }
 
       const page = route.query.page

--- a/pages/posts/[domain].vue
+++ b/pages/posts/[domain].vue
@@ -7,7 +7,7 @@
   import { FetchError } from 'ofetch'
   import type { Ref } from 'vue'
   import { toast } from 'vue-sonner'
-  import { generatePostsRoute } from '~/assets/js/RouterHelper'
+  import { fallbackBooruDomain, generatePostsRoute, getSingleQueryValue } from '~/assets/js/RouterHelper'
   import { tagArrayToTitle } from '~/assets/js/SeoHelper'
   import type { Domain } from '~/assets/js/domain'
   import type { IPost, IPostPage } from '~/assets/js/post.dto'
@@ -28,22 +28,7 @@
 
   const { selectedDomainFromStorage } = useSelectedDomainFromStorage()
 
-  const fallbackBooruDomain = 'rule34.xxx'
   const additionalBoorusPremiumSlideIndex = 4
-
-  function getSingleQueryValue(value: string | string[] | null | (string | null)[] | undefined) {
-    if (Array.isArray(value)) {
-      const firstValue = value[0]
-
-      return firstValue ?? undefined
-    }
-
-    if (value === null || value === undefined) {
-      return undefined
-    }
-
-    return value
-  }
 
   /**
    * Show ads for non-premium users


### PR DESCRIPTION
## Summary
- redirect non-premium visits to premium booru search pages over to `rule34.xxx` with preserved tags and tracking parameters
- reopen the existing Additional Boorus premium prompt after the redirect lands so unauthorized users still see the upsell
- strip redirect tracking params from canonical URLs to avoid indexing analytics-only query strings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Canonical URLs now strip tracking/attribution query parameters to avoid duplicate canonicals.

* **New Features**
  * Non-premium users requesting premium-only content are redirected to a fallback posts page (preserving tags and adding tracking fields) instead of an authorization error.
  * Premium upsell modal now reopens appropriately when redirected from a premium source.
  * Ads load only after interaction for non-premium users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->