### PR TITLE
fix: avoid Buffer in imgproxy provider

### DIFF
--- a/assets/js/nuxt-image/imgproxy.provider.ts
+++ b/assets/js/nuxt-image/imgproxy.provider.ts
@@ -1,6 +1,5 @@
 import { joinURL } from 'ufo'
 import type { ProviderGetImage } from '@nuxt/image'
-import { Buffer } from 'buffer'
 import { createOperationsGenerator, defineProvider } from '@nuxt/image/runtime'
 
 // https://docs.imgproxy.net/
@@ -38,7 +37,10 @@ const operationsGenerator = createOperationsGenerator({
 })
 
 function urlSafeBase64(string: string) {
-  return Buffer.from(string, 'utf8').toString('base64').replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_')
+  const bytes = new TextEncoder().encode(string)
+  const binaryString = Array.from(bytes, byte => String.fromCodePoint(byte)).join('')
+
+  return btoa(binaryString).replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_')
 }
 
 const defaultModifiers = {


### PR DESCRIPTION
## Summary
- replace the imgproxy provider's Node `Buffer` usage with browser-safe `TextEncoder` + `btoa`
- keep the same URL-safe base64 output shape without adding new dependencies
- fix client/browser builds that fail when Vite externalizes `buffer`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced browser compatibility for image encoding in the image proxy provider, ensuring more reliable image processing in web environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->