### PR TITLE
Restore tag sheet after collection handoff

### DIFF
--- a/app/components/pages/posts/post/PostComponent.vue
+++ b/app/components/pages/posts/post/PostComponent.vue
@@ -3,6 +3,7 @@
   import { generatePostTagLandingPath } from '~/assets/js/RouterHelper'
   import type { IPost } from '~/assets/js/post.dto'
   import Tag, { TagDTO } from '~/assets/js/tag.dto'
+  import { premiumPromotionIndices } from '~/composables/usePremiumDialog'
   import { project } from '~~/config/project'
 
   const props = defineProps<{
@@ -60,16 +61,34 @@
 
   const { postFullSizeImages } = useUserSettings()
   const { isPremium } = useUserData()
+  const { open: promptPremium, currentIndex } = usePremiumDialog()
 
   const areTagsOpen = ref(false)
   const isTagCollectionPickerOpen = ref(false)
   const activeTagForCollection = shallowRef<string | null>(null)
+  const shouldRestoreTagsOpen = ref(false)
 
   watch(isTagCollectionPickerOpen, (isOpen) => {
     if (!isOpen) {
       activeTagForCollection.value = null
+      restoreTagsSheet()
     }
   })
+
+  watch(promptPremium, (isOpen) => {
+    if (!isOpen) {
+      restoreTagsSheet()
+    }
+  })
+
+  function restoreTagsSheet() {
+    if (!shouldRestoreTagsOpen.value) {
+      return
+    }
+
+    shouldRestoreTagsOpen.value = false
+    areTagsOpen.value = true
+  }
 
   function createTag(name: string, type: PostTagType) {
     return new Tag(Object.assign(new TagDTO(), { name, type }))
@@ -77,6 +96,14 @@
 
   function onAddTagToCollection(tag: string) {
     areTagsOpen.value = false
+    shouldRestoreTagsOpen.value = true
+
+    if (!isPremium.value) {
+      currentIndex.value = premiumPromotionIndices.tagCollections
+      promptPremium.value = true
+      return
+    }
+
     activeTagForCollection.value = tag
     isTagCollectionPickerOpen.value = true
   }

--- a/app/components/pages/posts/post/PostTag.vue
+++ b/app/components/pages/posts/post/PostTag.vue
@@ -89,12 +89,6 @@
   }
 
   function addToCollection(tag: Tag) {
-    if (!isPremium.value) {
-      currentIndex.value = premiumPromotionIndices.tagCollections
-      promptPremium.value = true
-      return
-    }
-
     emit('addToCollection', tag.name)
   }
 </script>

--- a/test/pages/posts-tag-collections.test.ts
+++ b/test/pages/posts-tag-collections.test.ts
@@ -45,6 +45,8 @@ describe('Post tag collections', async () => {
       .poll(() => page.getByText('Tag added to collection').first().isVisible(), { timeout: 10000 })
       .toBe(true)
 
+    await expect.poll(() => page.getByRole('dialog').count(), { timeout: 10000 }).toBe(1)
+    await expect.poll(() => page.getByRole('dialog').getByText('General').isVisible(), { timeout: 10000 }).toBe(true)
     await expect.poll(() => pocketBase.tagCollectionRecords[0]?.tags, { timeout: 10000 }).toEqual(['animated', '1girl'])
   }, 60000)
 
@@ -150,5 +152,9 @@ describe('Post tag collections', async () => {
     const premiumPrompt = page.getByRole('dialog').first()
     await premiumPrompt.waitFor({ state: 'attached', timeout: 10000 })
     await expect(premiumPrompt.getAttribute('data-headlessui-state')).resolves.toBe('open')
+    await premiumPrompt.getByRole('button', { name: /close/i }).click()
+
+    await expect.poll(() => page.getByRole('dialog').count(), { timeout: 10000 }).toBe(1)
+    await expect.poll(() => page.getByRole('dialog').getByText('General').isVisible(), { timeout: 10000 }).toBe(true)
   }, 60000)
 })


### PR DESCRIPTION
## Summary
- Route post tag collection actions through `PostComponent` so it owns the modal handoff.
- Restore the tags sheet after closing the tag collection picker or premium prompt.
- Keep `PostTag` as a simple menu emitter for the add-to-collection action.

## Test Plan
- [x] `corepack pnpm vitest run test/pages/posts-tag-collections.test.ts`
- [x] `corepack pnpm exec prettier --check app/components/pages/posts/post/PostTag.vue app/components/pages/posts/post/PostComponent.vue test/pages/posts-tag-collections.test.ts`
- [x] `corepack pnpm typecheck`
- [x] `coderabbit review --agent -t uncommitted -c AGENTS.md` raised 0 issues before commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Premium promotion dialog now appears when non-premium users attempt to add tags to collections, with tag sheet state preserved upon dialog closure.

* **Tests**
  * Updated test cases to verify premium promotion dialog behavior and proper state management for tag operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->