### PR TITLE
Document Gelbooru media Worker requirements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,9 @@ deliberately generated at 1x density only (webp format) to reduce bandwidth.
   of patching rendered HTML in Nitro.
 - `PostMedia` uses imgproxy for SSR post images, including local development. Non-premium SPA navigations keep the direct
   image path; validate image delivery in an environment where imgproxy can resolve the source URL.
+- Gelbooru media is routed through Cloudflare Worker media proxies before imgproxy because Gelbooru rate-limits the VM
+  egress IP. Worker fetches must use clean upstream headers instead of forwarding inbound `CF-*`, `X-Forwarded-*`,
+  `X-Real-IP`, cookies, or authorization headers; leaked caller metadata can make imgproxy fetches return `429`.
 
 ### Headless UI
 


### PR DESCRIPTION
## Summary
- document that Gelbooru media relies on Cloudflare Worker media proxies before imgproxy
- record the production requirement that Worker upstream fetches use clean headers and do not forward caller/Cloudflare metadata

## Context
The deployed Worker header sanitation fixed the failing imgproxy sample. We intentionally removed the proposed cache-buster query param from generated App URLs.

## Verification
- corepack pnpm vitest run test/assets/imgproxy-provider.test.ts
- corepack pnpm typecheck
- corepack pnpm lint
