### PR TITLE
Fix unknown post media type handling

### DIFF
--- a/app/assets/js/post.dto.ts
+++ b/app/assets/js/post.dto.ts
@@ -26,6 +26,13 @@ export interface IPost {
   media_type: 'image' | 'animated' | 'video' | 'unknown' | null
 }
 
+export type PostMediaType = Exclude<IPost['media_type'], 'unknown' | null>
+export type IRenderablePost = IPost & { media_type: PostMediaType }
+
+export function isRenderablePost(post: IPost): post is IRenderablePost {
+  return post.media_type === 'image' || post.media_type === 'animated' || post.media_type === 'video'
+}
+
 export interface IPostFile {
   url: string | null
   width: number | null

--- a/app/components/pages/posts/post/PostChatWithAi.vue
+++ b/app/components/pages/posts/post/PostChatWithAi.vue
@@ -3,11 +3,11 @@
   import { flip, offset, shift, useFloating } from '@floating-ui/vue'
   import { useChatWithAiReferral } from '~/composables/useAdvertisements'
   import useAppStatistics from '~/composables/useAppStatistics'
-  import type { IPost } from '~/assets/js/post.dto'
+  import type { IPost, PostMediaType } from '~/assets/js/post.dto'
 
   const props = defineProps<{
     tags: IPost['tags']
-    mediaType: IPost['media_type']
+    mediaType: PostMediaType
     mediaUrl: string | null
   }>()
 

--- a/app/components/pages/posts/post/PostComponent.vue
+++ b/app/components/pages/posts/post/PostComponent.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
   import { ChevronDownIcon } from '@heroicons/vue/24/outline'
   import { generatePostTagLandingPath } from '~/assets/js/RouterHelper'
-  import type { IPost } from '~/assets/js/post.dto'
+  import type { IPost, IRenderablePost } from '~/assets/js/post.dto'
   import Tag, { TagDTO } from '~/assets/js/tag.dto'
   import { premiumPromotionIndices } from '~/composables/usePremiumDialog'
   import { project } from '~~/config/project'
@@ -9,7 +9,7 @@
   const props = defineProps<{
     postIndex: number
 
-    post: IPost
+    post: IRenderablePost
 
     selectedTags: Tag[]
   }>()
@@ -185,9 +185,6 @@
         data.posterFile = props.post.preview_file.url
         break
       }
-
-      default:
-        throw new Error('Unknown media type: ' + props.post.media_type)
     }
 
     data.file = stripFragment(data.file)

--- a/app/components/pages/posts/post/PostMedia.vue
+++ b/app/components/pages/posts/post/PostMedia.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-  import type { IPost } from '~/assets/js/post.dto'
+  import type { IPost, PostMediaType } from '~/assets/js/post.dto'
   import { vIntersectionObserver } from '@vueuse/components'
   import { proxyUrl } from '~/assets/js/proxy'
 
@@ -18,7 +18,7 @@
     mediaSrcHeight: IPost['high_res_file']['height'] | null
     mediaSrcWidth: IPost['high_res_file']['width'] | null
     mediaPosterSrc: string | null
-    mediaType: IPost['media_type']
+    mediaType: PostMediaType
     mediaAlt: string
   }
 

--- a/app/pages/posts/[domain]/[tag].vue
+++ b/app/pages/posts/[domain]/[tag].vue
@@ -2,7 +2,7 @@
   import { ArrowPathIcon, QuestionMarkCircleIcon } from '@heroicons/vue/24/solid'
   import { fallbackBooruDomain, generatePostsRoute, getSingleRouteParam } from '~/assets/js/RouterHelper'
   import { normalizeStringForTitle } from '~/assets/js/SeoHelper'
-  import type { IPost, IPostFile, IPostPage } from '~/assets/js/post.dto'
+  import { isRenderablePost, type IPostFile, type IPostPage, type IRenderablePost } from '~/assets/js/post.dto'
   import Tag, { TagDTO } from '~/assets/js/tag.dto'
   import { project } from '~~/config/project'
 
@@ -74,13 +74,11 @@
     }
   )
 
-  const posts = computed<IPost[]>(() =>
-    (data.value?.data ?? [])
-      .filter((post) => post.media_type)
-      .map((post) => ({
-        ...post,
-        domain: selectedBooru.value.domain
-      }))
+  const posts = computed<IRenderablePost[]>(() =>
+    (data.value?.data ?? []).filter(isRenderablePost).map((post) => ({
+      ...post,
+      domain: selectedBooru.value.domain
+    }))
   )
 
   const canonicalUrl = computed(() => new URL(route.path, project.urls.production).href)
@@ -91,13 +89,13 @@
     return firstPost.preview_file.url
   })
 
-  function getPostPreviewFile(post: IPost): IPostFile {
+  function getPostPreviewFile(post: IRenderablePost): IPostFile {
     if (post.preview_file.url) return post.preview_file
     if (post.low_res_file.url) return post.low_res_file
     return post.high_res_file
   }
 
-  function getPostPreviewAlt(post: IPost): string {
+  function getPostPreviewAlt(post: IRenderablePost): string {
     const tags = [...post.tags.character, ...post.tags.copyright, ...post.tags.artist, ...post.tags.general].filter(
       Boolean
     )
@@ -105,7 +103,7 @@
     return tags.length ? tags.slice(0, 5).join(', ') : t('media.postAlt', { id: post.id })
   }
 
-  function getPostAspectRatio(post: IPost): string {
+  function getPostAspectRatio(post: IRenderablePost): string {
     const previewFile = getPostPreviewFile(post)
 
     if (!previewFile.width || !previewFile.height) {

--- a/app/pages/posts/[domain]/index.vue
+++ b/app/pages/posts/[domain]/index.vue
@@ -18,7 +18,7 @@
   import { stripLocaleFromPath } from '~/composables/locale'
   import { useTagTitle } from '~/composables/useTagTitle'
   import type { Domain } from '~/assets/js/domain'
-  import type { IPost, IPostPage } from '~/assets/js/post.dto'
+  import { isRenderablePost, type IPostPage, type IRenderablePost } from '~/assets/js/post.dto'
   import Tag, { type ITag } from '~/assets/js/tag.dto'
   import { project } from '~~/config/project'
   import { premiumPromotionIndices } from '~/composables/usePremiumDialog'
@@ -28,7 +28,7 @@
     tags: Tag[]
     filters: Record<string, FilterValue>
   }
-  type PostRow = IPost & {
+  type PostRow = IRenderablePost & {
     current_page: number
     isFirstPost: boolean
   }
@@ -549,8 +549,7 @@
       page.data = page.data.filter((post) => {
         //
 
-        // Delete all posts that have `media_type: 'unknown'`
-        if (!post.media_type || post.media_type === 'unknown') {
+        if (!isRenderablePost(post)) {
           return false
         }
 
@@ -619,7 +618,7 @@
     return data.value.pages.flatMap((page) => {
       //
 
-      return page.data.flatMap((post, index) => {
+      return page.data.filter(isRenderablePost).flatMap((post, index) => {
         //
 
         return {

--- a/app/pages/premium/saved-posts/[domain].vue
+++ b/app/pages/premium/saved-posts/[domain].vue
@@ -9,13 +9,13 @@
   import type { Domain } from '~/assets/js/domain'
   import Tag from '~/assets/js/tag.dto'
   import { booruTypeList } from '~/assets/lib/rule-34-shared-resources/src/util/BooruUtils'
-  import type { IPost, IPostPage } from '~/assets/js/post.dto'
+  import { isRenderablePost, type IPostPage, type IRenderablePost } from '~/assets/js/post.dto'
   import { generatePostsRoute, getFilterQueryValue, getSingleQueryValue } from '~/assets/js/RouterHelper'
   import { useTagTitle } from '~/composables/useTagTitle'
   import { PremiumCloudRepository, type PremiumCloudPocketBaseClient } from '~/repositories/PremiumCloudRepository'
   import { project } from '~~/config/project'
 
-  type PostRow = IPost & {
+  type PostRow = IRenderablePost & {
     current_page: number
     isFirstPost: boolean
   }
@@ -393,7 +393,7 @@
     return data.value.pages.flatMap((page) => {
       //
 
-      return page.data.flatMap((post, index) => {
+      return page.data.filter(isRenderablePost).flatMap((post, index) => {
         // TODO: Optimize performance
 
         return {

--- a/test/pages/index.test.ts
+++ b/test/pages/index.test.ts
@@ -13,7 +13,7 @@ describe('/', async () => {
     const page = await createTrackedPage('/')
 
     await page.locator('h1', { hasText: 'App' }).isVisible()
-  })
+  }, 30000)
 
   it('redirects to /posts with query params', async () => {
     // Arrange
@@ -29,7 +29,7 @@ describe('/', async () => {
     expect(currentUrl.searchParams.get('domain')).toBe(null)
     expect(currentUrl.searchParams.get('page')).toBe('3')
     expect(currentUrl.searchParams.get('tags')).toBe('cat|black_hair')
-  })
+  }, 30000)
 
   it('links featured tags directly to post results', async () => {
     const page = await createTrackedPage('/')
@@ -40,5 +40,5 @@ describe('/', async () => {
     const href = await animatedLink.getAttribute('href')
     expect(href).toContain('/posts/rule34.xxx?tags=animated')
     expect(href).not.toContain('/posts/rule34.xxx/animated')
-  })
+  }, 30000)
 })

--- a/test/pages/posts.test.ts
+++ b/test/pages/posts.test.ts
@@ -129,6 +129,8 @@ describe('/', async () => {
       )
 
       // Act
+      await page.getByTestId('domain-selector').waitFor({ state: 'visible' })
+      await page.waitForLoadState('networkidle')
       await page.getByTestId('domain-selector').click({ force: true })
       const rule34Option = page.getByRole('option', { name: /rule34\.xxx/i })
       await rule34Option.waitFor({ state: 'visible' })
@@ -142,7 +144,7 @@ describe('/', async () => {
 
       releasePostsResponse?.()
       await page.getByTestId(`rule34.xxx-${mockPostsPage0.data[0].id}`).first().waitFor({ state: 'visible' })
-    }, 30000)
+    }, 60000)
 
     it('shows no results', async () => {
       // Arrange
@@ -391,7 +393,7 @@ describe('/', async () => {
       })
       await page.mouse.wheel(0, 100000)
       await page.waitForURL((u) => u.searchParams.get('tags') === 'hair_bun' && u.searchParams.get('page') !== '0', {
-        timeout: 10000
+        timeout: 30000
       })
 
       const currentUrl = page.url()
@@ -423,7 +425,7 @@ describe('/', async () => {
       // Assert
       expect(tagEntries).toHaveLength(1)
       expect(tagEntries[0].path).toContain(`page=${currentPage}`)
-    }, 20000)
+    }, 60000)
   })
 
   describe('Domain', async () => {
@@ -463,7 +465,7 @@ describe('/', async () => {
       const domainSelectorText = await page.getByTestId('domain-selector').textContent()
 
       expect(domainSelectorText).toContain('safebooru.org')
-    }, 15000)
+    }, 30000)
   })
 
   describe('SEO', async () => {

--- a/test/pages/premium-cloud.test.ts
+++ b/test/pages/premium-cloud.test.ts
@@ -148,6 +148,45 @@ describe('Premium cloud flows', async () => {
     expect(pocketBase.requests.some((request) => request.includes('distinct_original_domain_from_posts'))).toBe(false)
   }, 20000)
 
+  it('filters saved posts without a media type before rendering post media', async () => {
+    const page = await createTrackedPage()
+    const pageErrors: string[] = []
+    const savedPostRecordWithoutMediaType = {
+      ...firstSavedPostRecord,
+      media_type: undefined
+    }
+    const savedPostRecordWithUnknownMediaType = {
+      ...firstSavedPostRecord,
+      id: `${firstSavedPostRecord.id}-unknown`,
+      original_id: firstSavedPostRecord.original_id + 1,
+      media_type: 'unknown' as const
+    }
+    const pocketBase = createPocketBaseMockState({
+      savedPostSummaries: [
+        firstSavedPostSummary,
+        {
+          ...firstSavedPostSummary,
+          id: savedPostRecordWithUnknownMediaType.id!,
+          original_id: savedPostRecordWithUnknownMediaType.original_id
+        }
+      ],
+      savedPostRecords: [savedPostRecordWithoutMediaType, savedPostRecordWithUnknownMediaType]
+    })
+
+    page.on('pageerror', (error) => {
+      pageErrors.push(error.message)
+    })
+
+    await mockPocketBase(page, pocketBase)
+    await addPocketBaseAuthCookie(page, url('/'))
+    await page.goto(url('/premium/saved-posts/r34.app'), { waitUntil: 'domcontentloaded' })
+
+    await page.getByRole('heading', { name: /no results/i }).waitFor({ state: 'visible', timeout: 10000 })
+
+    expect(await page.locator('figure').count()).toBe(0)
+    expect(pageErrors.filter((message) => message.includes('Unknown media type'))).toEqual([])
+  }, 20000)
+
   it('redirects old saved-post domain URLs to the all-posts domain while preserving filters', async () => {
     const page = await createTrackedPage()
     const pocketBase = createPocketBaseMockState({


### PR DESCRIPTION
## Summary
- Add a shared renderable-post type guard for image, animated, and video posts
- Filter null/unknown media posts in parent data flows before PostComponent renders
- Tighten PostComponent/PostMedia/PostChatWithAi props so null/unknown media types are not accepted
- Add a Premium saved-post regression for missing and unknown PocketBase media_type records

Fixes R34-APP-6KQ

## Verification
- pnpm check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Exclude posts with missing or unknown media types from post feeds, previews, and premium saved post lists, preventing rendering errors and avoiding broken/empty media slots.

* **Tests**
  * Added an automated UI test covering premium saved posts with unset/unknown media types (verifies no runtime page errors and no media elements render).
  * Improved test stability with updated waits/timeouts for key navigation and rendering scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->