### PR TITLE
Fix stable virtual row keys

### DIFF
--- a/app/pages/posts/[domain]/index.vue
+++ b/app/pages/posts/[domain]/index.vue
@@ -649,6 +649,12 @@
     return {
       count: hasNextPage.value ? allRows.value.length + 1 : allRows.value.length,
 
+      getItemKey: (index: number) => {
+        const post = allRows.value[index]
+
+        return post ? getPostRowKey(post) : `${selectedBooru.value.domain}-next-page`
+      },
+
       estimateSize: () => estimatedRowSize,
 
       // For SSR
@@ -676,13 +682,14 @@
 
     return Array.from({ length: rowCount }, (_, index) => {
       const start = index * (estimatedRowSize + rowGap)
+      const post = allRows.value[index]
 
       return {
         index,
         start,
         size: estimatedRowSize,
         end: start + estimatedRowSize,
-        key: index,
+        key: post ? getPostRowKey(post) : `${selectedBooru.value.domain}-next-page`,
         lane: 0
       }
     })
@@ -710,6 +717,10 @@
     }
 
     return post
+  }
+
+  function getPostRowKey(post: Pick<PostRow, 'domain' | 'id'>) {
+    return `${post.domain}-${post.id}`
   }
 
   // Next page loader
@@ -1175,6 +1186,7 @@
               :key="String(virtualRow.key)"
               :ref="measureElement"
               :data-index="virtualRow.index"
+              :data-virtual-key="String(virtualRow.key)"
               :data-testid="
                 virtualRow.index <= allRows.length - 1
                   ? `${getPostRow(virtualRow.index).domain}-${getPostRow(virtualRow.index).id}`
@@ -1221,9 +1233,8 @@
                 </button>
 
                 <!-- Post -->
-                <!-- Fix: use domain + post.id as unique key, since virtualRow.index could be the same on different Boorus/pages -->
                 <PostComponent
-                  :key="selectedBooru.domain + '-' + getPostRow(virtualRow.index).id"
+                  :key="getPostRowKey(getPostRow(virtualRow.index))"
                   :post="getPostRow(virtualRow.index)"
                   :post-index="virtualRow.index"
                   :selected-tags="selectedTags"

--- a/app/pages/premium/saved-posts/[domain].vue
+++ b/app/pages/premium/saved-posts/[domain].vue
@@ -421,6 +421,12 @@
     return {
       count: hasNextPage.value ? allRows.value.length + 1 : allRows.value.length,
 
+      getItemKey: (index: number) => {
+        const post = allRows.value[index]
+
+        return post ? getPostRowKey(post) : `${savedPostsBooru.domain}-next-page`
+      },
+
       estimateSize: () => 600,
 
       // For SSR
@@ -500,6 +506,10 @@
     }
 
     return post
+  }
+
+  function getPostRowKey(post: Pick<PostRow, 'domain' | 'id'>) {
+    return `${post.domain}-${post.id}`
   }
 
   /**
@@ -736,6 +746,7 @@
               :key="String(virtualRow.key)"
               :ref="measureElement"
               :data-index="virtualRow.index"
+              :data-virtual-key="String(virtualRow.key)"
             >
               <!-- Next Pagination -->
               <div
@@ -776,9 +787,8 @@
                 </button>
 
                 <!-- Post -->
-                <!-- Fix: use domain + post.id as unique key, since virtualRow.index could be the same on different Boorus/pages -->
                 <PostComponent
-                  :key="getPostRow(virtualRow.index).domain + '-' + getPostRow(virtualRow.index).id"
+                  :key="getPostRowKey(getPostRow(virtualRow.index))"
                   :post="getPostRow(virtualRow.index)"
                   :post-index="virtualRow.index"
                   :selected-tags="selectedTags"

--- a/test/pages/posts.test.ts
+++ b/test/pages/posts.test.ts
@@ -305,6 +305,21 @@ describe('/', async () => {
         mockPostsPage1.data[0].low_res_file.url
       )
     }, 30000)
+
+    it('uses post identity for virtual row keys', async () => {
+      const page = await createTrackedPage()
+
+      await page.goto(url('/posts/safebooru.org'), { waitUntil: 'domcontentloaded' })
+      await page.getByTestId(`safebooru.org-${mockPostsPage0.data[0].id}`).first().waitFor({ state: 'visible' })
+
+      const firstVirtualKey = await page
+        .getByTestId('posts-list')
+        .locator('li')
+        .first()
+        .getAttribute('data-virtual-key')
+
+      expect(firstVirtualKey).toBe(`safebooru.org-${mockPostsPage0.data[0].id}`)
+    }, 30000)
   })
 
   describe('History', async () => {


### PR DESCRIPTION
## Summary
- add stable TanStack Virtual item keys based on post domain/id for post lists
- keep SSR fallback virtual rows keyed the same way as client virtual rows
- reuse the same post row key for the child post component and expose it for regression coverage

## Sentry
Fixes R34-APP-22G

Sentry/Seer pointed to Vue patching virtualized post rows after rapid data/scroll changes. The virtualizer was still using its default index keys, so route/query data swaps could reuse outer row identity while the child post identity changed underneath it.

## Verification
- pnpm vitest run test/pages/posts.test.ts --testNamePattern "uses post identity for virtual row keys" 
- pnpm vitest run test/pages/posts.test.ts test/pages/premium-cloud.test.ts
- pnpm check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced post list rendering consistency across posts and saved posts pages by improving how posts are tracked internally during scrolling and pagination.

* **Tests**
  * Added verification tests for post list rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->