### PR TITLE
Stop reporting handled tag search fetch failures

### DIFF
--- a/app/assets/js/tag-search-error.ts
+++ b/app/assets/js/tag-search-error.ts
@@ -1,0 +1,5 @@
+import { FetchError } from 'ofetch'
+
+export function shouldReportTagSearchError(error: unknown) {
+  return !(error instanceof FetchError)
+}

--- a/app/assets/js/tag-search-error.ts
+++ b/app/assets/js/tag-search-error.ts
@@ -1,5 +1,5 @@
 import { FetchError } from 'ofetch'
 
-export function shouldReportTagSearchError(error: unknown) {
+export function shouldReportTagSearchError(error: unknown): boolean {
   return !(error instanceof FetchError)
 }

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -4,6 +4,7 @@
   import type { Domain } from '~/assets/js/domain'
   import { ArrowRightIcon } from '@heroicons/vue/24/solid'
   import { FetchError } from 'ofetch'
+  import { shouldReportTagSearchError } from '~/assets/js/tag-search-error'
   import { project } from '~~/config/project'
 
   type FeaturedTagMedia = {
@@ -100,8 +101,10 @@
 
       searchTagResults.value = response.data.map((tag) => new Tag(tag))
     } catch (error) {
-      const Sentry = await import('@sentry/nuxt')
-      Sentry.captureException(error)
+      if (shouldReportTagSearchError(error)) {
+        const Sentry = await import('@sentry/nuxt')
+        Sentry.captureException(error)
+      }
 
       searchTagResults.value = []
 

--- a/app/pages/posts/[domain]/index.vue
+++ b/app/pages/posts/[domain]/index.vue
@@ -19,6 +19,7 @@
   import { useTagTitle } from '~/composables/useTagTitle'
   import type { Domain } from '~/assets/js/domain'
   import type { IPost, IPostPage } from '~/assets/js/post.dto'
+  import { shouldReportTagSearchError } from '~/assets/js/tag-search-error'
   import Tag, { type ITag } from '~/assets/js/tag.dto'
   import { project } from '~~/config/project'
   import { premiumPromotionIndices } from '~/composables/usePremiumDialog'
@@ -304,9 +305,11 @@
         }
       })
     } catch (error) {
-      const Sentry = await import('@sentry/nuxt')
+      if (shouldReportTagSearchError(error)) {
+        const Sentry = await import('@sentry/nuxt')
 
-      Sentry.captureException(error)
+        Sentry.captureException(error)
+      }
 
       if (error instanceof FetchError) {
         switch (error.status) {

--- a/test/assets/tag-search-error.test.ts
+++ b/test/assets/tag-search-error.test.ts
@@ -1,0 +1,13 @@
+import { FetchError } from 'ofetch'
+import { describe, expect, it } from 'vitest'
+import { shouldReportTagSearchError } from '../../app/assets/js/tag-search-error'
+
+describe('tag search error reporting', () => {
+  it('does not report handled fetch failures to Sentry', () => {
+    expect(shouldReportTagSearchError(new FetchError('Service unavailable'))).toBe(false)
+  })
+
+  it('reports unexpected non-fetch errors to Sentry', () => {
+    expect(shouldReportTagSearchError(new Error('Unexpected tag search failure'))).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- stop manually reporting handled tag autocomplete FetchErrors to Sentry
- keep existing user-facing toast handling for 404, 429, and other fetch failures
- add a small tested helper so unexpected non-fetch errors can still be reported

## Sentry
Fixes R34-APP-8KA
Fixes R34-APP-8K8
Fixes R34-APP-7MR
Fixes R34-APP-7MC
Fixes R34-APP-8QG
Fixes R34-APP-8J4

These groups are handled autocomplete fetch failures from the same manual Sentry capture path. They do not crash the page; the UI already shows a toast.

## Verification
- pnpm vitest run test/assets/tag-search-error.test.ts
- pnpm vitest run test/assets/tag-search-error.test.ts test/pages/posts.test.ts test/pages/index.test.ts
- pnpm check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tag-search error handling to only send critical errors to error tracking while preserving existing user-facing messages; common fetch errors are handled locally.
* **Tests**
  * Added tests to verify which tag-search errors are reported vs. suppressed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->