### PR TITLE
Filter Safari native track menu errors

### DIFF
--- a/sentry.client.options.ts
+++ b/sentry.client.options.ts
@@ -45,6 +45,10 @@ export function buildSentryClientInitOptions(params: {
         return null
       }
 
+      if (isSafariNativeTrackMenuError(event)) {
+        return null
+      }
+
       // The Nuxt Sentry SDK calls `beforeSend` for error events. The SDK typing
       // expects an ErrorEvent return type here, so we narrow accordingly.
       return event as Sentry.ErrorEvent
@@ -244,4 +248,11 @@ export function isInjectedCode(event: Sentry.Event | undefined): boolean {
   }
 
   return false
+}
+
+export function isSafariNativeTrackMenuError(event: Sentry.Event | undefined): boolean {
+  const frames = event?.exception?.values?.[0]?.stacktrace?.frames
+  if (!frames || frames.length === 0) return false
+
+  return frames.some((frame) => frame.function === 'sortedTrackListForMenu' && frame.filename === '[native code]')
 }

--- a/test/assets/sentry-client-options.test.ts
+++ b/test/assets/sentry-client-options.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { isSafariNativeTrackMenuError } from '../../sentry.client.options'
+
+describe('Sentry client options', () => {
+  it('identifies Safari native track menu errors', () => {
+    expect(
+      isSafariNativeTrackMenuError({
+        exception: {
+          values: [
+            {
+              stacktrace: {
+                frames: [
+                  {
+                    function: 'sortedTrackListForMenu',
+                    filename: '[native code]'
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      })
+    ).toBe(true)
+  })
+
+  it('does not match unrelated native errors', () => {
+    expect(
+      isSafariNativeTrackMenuError({
+        exception: {
+          values: [
+            {
+              stacktrace: {
+                frames: [
+                  {
+                    function: 'webkitEnterFullscreen',
+                    filename: '[native code]'
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      })
+    ).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- drop Safari native `sortedTrackListForMenu` events in Sentry `beforeSend`
- keep the filter scoped to the native stack frame/function pair
- add unit coverage for the positive and unrelated-native negative cases

## Sentry
Fixes R34-APP-4W3

This issue has no first-party stack frames and comes from Safari native video track menu code. The replay shows page interaction around search/results, but the event itself is browser-native noise rather than an app exception.

## Verification
- pnpm vitest run test/assets/sentry-client-options.test.ts
- pnpm check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error tracking to filter out Safari browser-specific native track menu errors, reducing noise in error reports and alerts.

* **Tests**
  * Added comprehensive test coverage validating the Safari native error filtering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->