### PR TITLE
Fix posts virtualizer measurement

### DIFF
--- a/app/assets/js/virtualizer-measurement.ts
+++ b/app/assets/js/virtualizer-measurement.ts
@@ -1,0 +1,18 @@
+type VirtualizerMeasurementTarget = {
+  measureElement: (element: Element | null) => void
+}
+
+export function measureVirtualItemsAfterVueUpdate(params: {
+  elements: Array<Element | null>
+  virtualizer: VirtualizerMeasurementTarget
+}) {
+  const { elements, virtualizer } = params
+
+  virtualizer.measureElement(null)
+
+  for (const element of elements) {
+    if (element?.isConnected) {
+      virtualizer.measureElement(element)
+    }
+  }
+}

--- a/app/pages/posts/[domain]/index.vue
+++ b/app/pages/posts/[domain]/index.vue
@@ -642,7 +642,7 @@
   const parentRef = ref<HTMLElement | null>(null)
   const parentOffsetRef = ref(0)
   const isClientVirtualizerReady = ref(false)
-  const virtualItemEls = shallowRef<HTMLElement[]>([])
+  const virtualItemEls = ref<HTMLElement[]>([])
 
   onMounted(() => {
     parentOffsetRef.value = parentRef.value?.offsetTop ?? 0

--- a/app/pages/posts/[domain]/index.vue
+++ b/app/pages/posts/[domain]/index.vue
@@ -642,7 +642,7 @@
   const parentRef = ref<HTMLElement | null>(null)
   const parentOffsetRef = ref(0)
   const isClientVirtualizerReady = ref(false)
-  const virtualItemEls = ref<HTMLElement[]>([])
+  const virtualItemEls = useTemplateRef<HTMLElement[]>('virtualItemEls')
 
   onMounted(() => {
     parentOffsetRef.value = parentRef.value?.offsetTop ?? 0
@@ -790,7 +790,7 @@
 
   function measureVirtualRows() {
     measureVirtualItemsAfterVueUpdate({
-      elements: virtualItemEls.value,
+      elements: virtualItemEls.value ?? [],
       virtualizer: rowVirtualizer.value
     })
   }

--- a/app/pages/posts/[domain]/index.vue
+++ b/app/pages/posts/[domain]/index.vue
@@ -6,7 +6,8 @@
   import { useWindowVirtualizer } from '@tanstack/vue-virtual'
   import { cloneDeep, throttle } from 'es-toolkit'
   import { FetchError } from 'ofetch'
-  import type { ComponentPublicInstance, Ref } from 'vue'
+  import type { Ref } from 'vue'
+  import { measureVirtualItemsAfterVueUpdate } from '~/assets/js/virtualizer-measurement'
   import {
     fallbackBooruDomain,
     generatePostsRoute,
@@ -641,6 +642,7 @@
   const parentRef = ref<HTMLElement | null>(null)
   const parentOffsetRef = ref(0)
   const isClientVirtualizerReady = ref(false)
+  const virtualItemEls = shallowRef<HTMLElement[]>([])
 
   onMounted(() => {
     parentOffsetRef.value = parentRef.value?.offsetTop ?? 0
@@ -711,15 +713,43 @@
     isClientVirtualizerReady.value ? rowVirtualizer.value.getTotalSize() : initialTotalSize.value
   )
 
-  function getPostRow(index: number): PostRow {
-    const post = allRows.value[index]
+  type RenderVirtualItem = (typeof virtualRows.value)[number]
+  type RenderVirtualRow =
+    | {
+        kind: 'post'
+        key: string
+        virtualRow: RenderVirtualItem
+        post: PostRow
+        dataTestId: string
+      }
+    | {
+        kind: 'next-page'
+        key: string
+        virtualRow: RenderVirtualItem
+      }
 
-    if (!post) {
-      throw new Error(`Post row ${index} not found`)
-    }
+  const renderRows = computed<RenderVirtualRow[]>(() =>
+    virtualRows.value.map((virtualRow) => {
+      const post = allRows.value[virtualRow.index]
+      const key = String(virtualRow.key)
 
-    return post
-  }
+      if (!post) {
+        return {
+          kind: 'next-page',
+          key,
+          virtualRow
+        }
+      }
+
+      return {
+        kind: 'post',
+        key,
+        virtualRow,
+        post,
+        dataTestId: getPostRowKey(post)
+      }
+    })
+  )
 
   function getPostRowKey(post: Pick<PostRow, 'domain' | 'id'>) {
     return `${post.domain}-${post.id}`
@@ -758,16 +788,15 @@
     }
   })
 
-  // FIX: Remove when this issue is fixed - https://github.com/TanStack/virtual/issues/619#issuecomment-1969516091
-  const measureElement = (el: Element | ComponentPublicInstance | null) => {
-    nextTick(() => {
-      if (!(el instanceof Element)) {
-        return
-      }
-
-      rowVirtualizer.value.measureElement(el)
+  function measureVirtualRows() {
+    measureVirtualItemsAfterVueUpdate({
+      elements: virtualItemEls.value,
+      virtualizer: rowVirtualizer.value
     })
   }
+
+  onMounted(measureVirtualRows)
+  onUpdated(measureVirtualRows)
 
   /**
    * Helper to translate filter values to localized labels
@@ -1184,20 +1213,16 @@
             class="space-y-4"
           >
             <li
-              v-for="virtualRow in virtualRows"
-              :key="String(virtualRow.key)"
-              :ref="measureElement"
-              :data-index="virtualRow.index"
-              :data-virtual-key="String(virtualRow.key)"
-              :data-testid="
-                virtualRow.index <= allRows.length - 1
-                  ? `${getPostRow(virtualRow.index).domain}-${getPostRow(virtualRow.index).id}`
-                  : undefined
-              "
+              v-for="row in renderRows"
+              :key="row.key"
+              ref="virtualItemEls"
+              :data-index="row.virtualRow.index"
+              :data-virtual-key="row.key"
+              :data-testid="row.kind === 'post' ? row.dataTestId : undefined"
             >
               <!-- Next Pagination -->
               <div
-                v-if="virtualRow.index > allRows.length - 1"
+                v-if="row.kind === 'next-page'"
                 data-testid="load-next-page"
                 class="flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium text-base-content"
               >
@@ -1226,19 +1251,18 @@
                 <!-- Page indicator -->
                 <!-- TODO: Show individually, not attached to a post-->
                 <button
-                  v-if="virtualRow.index !== 0 && getPostRow(virtualRow.index).isFirstPost"
+                  v-if="row.virtualRow.index !== 0 && row.post.isFirstPost"
                   class="mx-auto mb-4 block rounded-md px-1.5 py-1 text-sm hover:hover-bg-util hover:hover-text-util focus-visible:focus-outline-util"
                   type="button"
                   @click="onPageIndicatorClick"
                 >
-                  &dharl; {{ $t('common.pageNumber', { page: getPostRow(virtualRow.index).current_page }) }} &dharr;
+                  &dharl; {{ $t('common.pageNumber', { page: row.post.current_page }) }} &dharr;
                 </button>
 
                 <!-- Post -->
                 <PostComponent
-                  :key="getPostRowKey(getPostRow(virtualRow.index))"
-                  :post="getPostRow(virtualRow.index)"
-                  :post-index="virtualRow.index"
+                  :post="row.post"
+                  :post-index="row.virtualRow.index"
                   :selected-tags="selectedTags"
                   @add-tag="onPostAddTag"
                   @open-tag-in-new-tab="onPostOpenTagInNewTab"
@@ -1246,7 +1270,7 @@
                 />
 
                 <!-- Promoted content -->
-                <template v-if="!isPremium && virtualRow.index !== 0 && virtualRow.index % 7 === 0">
+                <template v-if="!isPremium && row.virtualRow.index !== 0 && row.virtualRow.index % 7 === 0">
                   <LazyPromotedContent class="mt-4" />
                 </template>
               </template>

--- a/test/assets/virtualizer-measurement.test.ts
+++ b/test/assets/virtualizer-measurement.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { measureVirtualItemsAfterVueUpdate } from '../../app/assets/js/virtualizer-measurement'
+
+describe('virtualizer measurement', () => {
+  it('cleans stale cached elements before measuring connected virtual rows', () => {
+    const measured: Array<Element | null> = []
+    const connected = { isConnected: true } as Element
+    const disconnected = { isConnected: false } as Element
+
+    measureVirtualItemsAfterVueUpdate({
+      elements: [connected, null, disconnected],
+      virtualizer: {
+        measureElement(element) {
+          measured.push(element)
+        }
+      }
+    })
+
+    expect(measured).toEqual([null, connected])
+  })
+})

--- a/test/pages/posts.test.ts
+++ b/test/pages/posts.test.ts
@@ -246,7 +246,8 @@ describe('/', async () => {
       })
 
       await page.goto(url('/posts/safebooru.org'), { waitUntil: 'domcontentloaded' })
-      await page.getByTestId(`safebooru.org-${mockPostsPage0.data[0].id}`).first().waitFor({ state: 'visible' })
+      const firstPost = page.getByTestId(`safebooru.org-${mockPostsPage0.data[0].id}`).first()
+      await firstPost.waitFor({ state: 'visible' })
 
       await page.route(
         '**/booru/gelbooru/posts*pageID=1*',
@@ -354,7 +355,8 @@ describe('/', async () => {
       })
 
       await page.goto(url('/posts/safebooru.org'), { waitUntil: 'domcontentloaded' })
-      await page.getByTestId(`safebooru.org-${mockPostsPage0.data[0].id}`).first().waitFor({ state: 'visible' })
+      const firstPost = page.getByTestId(`safebooru.org-${mockPostsPage0.data[0].id}`).first()
+      await firstPost.waitFor({ state: 'visible' })
 
       await page.evaluate(async () => {
         window.scrollTo(0, document.body.scrollHeight)
@@ -363,7 +365,15 @@ describe('/', async () => {
         await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))
       })
 
-      await page.goto(url('/posts/safebooru.org?tags=1girl'), { waitUntil: 'domcontentloaded' })
+      await firstPost.getByRole('button', { name: /tags/i }).click()
+      await page
+        .getByRole('button', { name: /^1girl$/ })
+        .first()
+        .click()
+      await Promise.all([
+        page.waitForURL('**/posts/safebooru.org?tags=1girl'),
+        page.getByRole('menuitem', { name: /set tag/i }).click()
+      ])
       await page.getByTestId(`safebooru.org-${mockPostsPage1.data[0].id}`).first().waitFor({ state: 'visible' })
 
       await page.evaluate(async () => {

--- a/test/pages/posts.test.ts
+++ b/test/pages/posts.test.ts
@@ -322,6 +322,59 @@ describe('/', async () => {
 
       expect(firstVirtualKey).toBe(`safebooru.org-${mockPostsPage0.data[0].id}`)
     }, 30000)
+
+    it('does not emit Vue patch errors while virtual rows scroll and route results change', async () => {
+      const page = await createTrackedPage()
+      const errorSignatures = [
+        'emitsOptions',
+        'nextSibling',
+        "Cannot destructure property 'bum'",
+        "null is not an object (evaluating 'i.emitsOptions')"
+      ]
+      const errors: string[] = []
+
+      page.on('pageerror', (error) => {
+        const message = error.message
+
+        if (errorSignatures.some((signature) => message.includes(signature))) {
+          errors.push(message)
+        }
+      })
+
+      page.on('console', (message) => {
+        if (message.type() !== 'error') {
+          return
+        }
+
+        const text = message.text()
+
+        if (errorSignatures.some((signature) => text.includes(signature))) {
+          errors.push(text)
+        }
+      })
+
+      await page.goto(url('/posts/safebooru.org'), { waitUntil: 'domcontentloaded' })
+      await page.getByTestId(`safebooru.org-${mockPostsPage0.data[0].id}`).first().waitFor({ state: 'visible' })
+
+      await page.evaluate(async () => {
+        window.scrollTo(0, document.body.scrollHeight)
+        await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))
+        window.scrollTo(0, 0)
+        await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))
+      })
+
+      await page.goto(url('/posts/safebooru.org?tags=1girl'), { waitUntil: 'domcontentloaded' })
+      await page.getByTestId(`safebooru.org-${mockPostsPage1.data[0].id}`).first().waitFor({ state: 'visible' })
+
+      await page.evaluate(async () => {
+        window.scrollTo(0, document.body.scrollHeight)
+        await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))
+        window.scrollTo(0, 0)
+        await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))
+      })
+
+      expect(errors).toEqual([])
+    }, 30000)
   })
 
   describe('History', async () => {


### PR DESCRIPTION
## Summary
- replace the posts-page TanStack virtualizer callback ref workaround with the newer Vue post-update measurement cleanup pattern
- render virtual rows from stable mapped row objects instead of repeated index lookups in the template
- add focused coverage for stale virtualizer element cleanup and scroll/navigation Vue patch errors

## Test Plan
- [x] `rtk pnpm vitest run test/assets/virtualizer-measurement.test.ts test/pages/posts.test.ts`
- [!] `rtk pnpm check` was attempted in a clean worktree but fails on the pre-existing `ofetch` direct-dependency issue; a clean `origin/main` worktree reproduces the same failure with `test/assets/tag-search-error.test.ts` importing `ofetch`.

## Notes
- This intentionally excludes the chunk-load recovery strategy from PR #139 so we can rethink it separately after research.
- This also excludes Nuxt/Sentry dependency updates from the combined PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved virtualized posts rendering by centralizing and refreshing item measurements after DOM updates, which helps prevent stale sizing data and results in more stable scrolling.
  * Enhanced pagination reliability, including smoother transitions when navigating to tagged results.
* **Tests**
  * Added coverage for virtualization measurement cleanup to ensure only connected elements are measured.
  * Strengthened pagination tests to detect and prevent Vue/virtual-row related console or page error regressions during route transitions and subsequent scrolling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->