### PR TITLE
Handle client chunk load recovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,6 +158,13 @@ deliberately generated at 1x density only (webp format) to reduce bandwidth.
 - Do not add `provideHeadlessUseId` in `app/app.vue` while the project uses Vue 3.5+ and `@headlessui/vue` 1.7.23+; those
   versions use Vue's native `useId` and the Nuxt Headless UI workaround is only for older versions.
 
+### Vue template refs
+
+- For DOM refs collected from `v-for`, prefer Vue 3.5's `useTemplateRef()` API over a hand-rolled `ref([])` or
+  `shallowRef([])`. Vue implements `useTemplateRef()` with a shallow ref internally, which is the right behavior for DOM
+  nodes that are read after render for measurement or imperative integration. Keep a null fallback at the call site
+  (`templateRef.value ?? []`) when the consumer expects an array.
+
 ### Toasts
 
 - `useLazyToast()` lazy-loads `vue-sonner` and renders `ClientToaster` on first use. The first toast must wait for

--- a/app/assets/js/chunk-error-recovery.ts
+++ b/app/assets/js/chunk-error-recovery.ts
@@ -1,0 +1,96 @@
+import type * as Sentry from '@sentry/nuxt'
+
+const chunkLoadMessagePatterns = [
+  /Importing a module script failed/i,
+  /Failed to fetch dynamically imported module/i,
+  /error loading dynamically imported module/i,
+  /Loading chunk \S+ failed/i,
+  /Loading CSS chunk \S+ failed/i,
+  /ChunkLoadError/i
+]
+
+export const chunkRecoveryStorageKeyPrefix = 'r34:chunk-recovery'
+export const chunkRecoveryAttemptMaxAgeMs = 5 * 60 * 1000
+
+export function getRecoverableChunkLoadMessage(error: unknown): string | null {
+  const message = getErrorMessage(error)
+
+  if (!message) {
+    return null
+  }
+
+  return chunkLoadMessagePatterns.some((pattern) => pattern.test(message)) ? message : null
+}
+
+export function getRecoverableChunkLoadMessageFromSentryEvent(event: Sentry.Event): string | null {
+  const exceptionValue = event.exception?.values?.find((value) => value.value)?.value
+  const message = exceptionValue ?? event.message
+
+  return getRecoverableChunkLoadMessage(message)
+}
+
+export function buildChunkRecoveryStorageKey(url: string): string {
+  return `${chunkRecoveryStorageKeyPrefix}:${url}`
+}
+
+export function shouldAttemptChunkRecovery(params: {
+  storage: Pick<Storage, 'getItem'>
+  key: string
+  online: boolean
+  now?: number
+}): boolean {
+  const { storage, key, online, now = Date.now() } = params
+
+  if (!online) {
+    return false
+  }
+
+  const storedRecoveryAttemptedAt = storage.getItem(key)
+
+  if (storedRecoveryAttemptedAt == null) {
+    return true
+  }
+
+  const recoveryAttemptedAt = Number(storedRecoveryAttemptedAt)
+
+  return !Number.isFinite(recoveryAttemptedAt) || now - recoveryAttemptedAt > chunkRecoveryAttemptMaxAgeMs
+}
+
+export function markChunkRecoveryAttempted(params: { storage: Pick<Storage, 'setItem'>; key: string; now?: number }) {
+  params.storage.setItem(params.key, String(params.now ?? Date.now()))
+}
+
+export function hasRecentChunkRecoveryAttemptForCurrentUrl(now = Date.now()): boolean {
+  if (typeof window === 'undefined') {
+    return false
+  }
+
+  try {
+    return !shouldAttemptChunkRecovery({
+      storage: sessionStorage,
+      key: buildChunkRecoveryStorageKey(window.location.href),
+      online: true,
+      now
+    })
+  } catch {
+    return false
+  }
+}
+
+function getErrorMessage(error: unknown): string | null {
+  if (typeof error === 'string') {
+    return error
+  }
+
+  if (error instanceof Error) {
+    return error.message
+  }
+
+  if (typeof error === 'object' && error != null && 'message' in error) {
+    const message = (error as { message?: unknown }).message
+
+    return typeof message === 'string' ? message : null
+  }
+
+  return null
+}

--- a/app/plugins/010.chunk-recovery.client.ts
+++ b/app/plugins/010.chunk-recovery.client.ts
@@ -1,0 +1,55 @@
+import {
+  buildChunkRecoveryStorageKey,
+  getRecoverableChunkLoadMessage,
+  markChunkRecoveryAttempted,
+  shouldAttemptChunkRecovery
+} from '~/assets/js/chunk-error-recovery'
+
+type VitePreloadErrorEvent = Event & {
+  payload?: unknown
+}
+
+export default defineNuxtPlugin((nuxtApp) => {
+  nuxtApp.hook('app:chunkError', (error) => {
+    if (!getRecoverableChunkLoadMessage(error)) {
+      return
+    }
+
+    recoverFromChunkError()
+  })
+
+  window.addEventListener('vite:preloadError', (event) => {
+    const preloadErrorEvent = event as VitePreloadErrorEvent
+
+    if (!getRecoverableChunkLoadMessage(preloadErrorEvent.payload ?? preloadErrorEvent)) {
+      return
+    }
+
+    preloadErrorEvent.preventDefault()
+    recoverFromChunkError()
+  })
+})
+
+function recoverFromChunkError() {
+  const key = buildChunkRecoveryStorageKey(window.location.href)
+
+  try {
+    if (shouldAttemptChunkRecovery({ storage: sessionStorage, key, online: navigator.onLine !== false })) {
+      markChunkRecoveryAttempted({ storage: sessionStorage, key })
+      reloadNuxtApp({ persistState: true })
+      return
+    }
+  } catch {
+    reloadNuxtApp({ persistState: true })
+    return
+  }
+
+  showError(
+    createError({
+      statusCode: 503,
+      statusMessage: 'App update required',
+      message: 'The app could not load the latest files. Refresh the page to try again.',
+      fatal: true
+    })
+  )
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -178,7 +178,7 @@ export default defineNuxtConfig({
 
   experimental: {
     // @see https://nuxt.com/docs/guide/going-further/experimental-features#emitroutechunkerror
-    emitRouteChunkError: 'automatic-immediate',
+    emitRouteChunkError: 'manual',
 
     defaults: {
       nuxtLink: {

--- a/sentry.client.options.ts
+++ b/sentry.client.options.ts
@@ -1,4 +1,8 @@
 import type * as Sentry from '@sentry/nuxt'
+import {
+  getRecoverableChunkLoadMessageFromSentryEvent,
+  hasRecentChunkRecoveryAttemptForCurrentUrl
+} from './app/assets/js/chunk-error-recovery'
 import { project } from './config/project'
 
 type SentryNuxtInitOptions = Parameters<typeof import('@sentry/nuxt').init>[0]
@@ -49,6 +53,10 @@ export function buildSentryClientInitOptions(params: {
         return null
       }
 
+      if (shouldDropRecoverableChunkLoadEvent(event)) {
+        return null
+      }
+
       // The Nuxt Sentry SDK calls `beforeSend` for error events. The SDK typing
       // expects an ErrorEvent return type here, so we narrow accordingly.
       return event as Sentry.ErrorEvent
@@ -59,6 +67,14 @@ export function buildSentryClientInitOptions(params: {
   }
 
   return options
+}
+
+export function shouldDropRecoverableChunkLoadEvent(event: Sentry.Event): boolean {
+  if (!getRecoverableChunkLoadMessageFromSentryEvent(event)) {
+    return false
+  }
+
+  return hasRecentChunkRecoveryAttemptForCurrentUrl()
 }
 
 const denyUrls: RegExp[] = [

--- a/test/assets/chunk-error-recovery.test.ts
+++ b/test/assets/chunk-error-recovery.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildChunkRecoveryStorageKey,
+  chunkRecoveryAttemptMaxAgeMs,
+  getRecoverableChunkLoadMessage,
+  markChunkRecoveryAttempted,
+  shouldAttemptChunkRecovery
+} from '../../app/assets/js/chunk-error-recovery'
+
+class MemoryStorage implements Pick<Storage, 'getItem' | 'setItem'> {
+  private readonly values = new Map<string, string>()
+
+  getItem(key: string) {
+    return this.values.get(key) ?? null
+  }
+
+  setItem(key: string, value: string) {
+    this.values.set(key, value)
+  }
+}
+
+describe('chunk error recovery', () => {
+  it('recognizes recoverable dynamic import failures', () => {
+    expect(getRecoverableChunkLoadMessage(new TypeError('Importing a module script failed.'))).toBe(
+      'Importing a module script failed.'
+    )
+    expect(getRecoverableChunkLoadMessage(new Error('Failed to fetch dynamically imported module'))).toBe(
+      'Failed to fetch dynamically imported module'
+    )
+    expect(getRecoverableChunkLoadMessage(new Error('Cannot read properties of null'))).toBeNull()
+  })
+
+  it('retries a chunk failure once per URL for a short recovery window', () => {
+    const storage = new MemoryStorage()
+    const key = buildChunkRecoveryStorageKey('https://r34.app/posts/rule34.xxx')
+
+    expect(shouldAttemptChunkRecovery({ storage, key, online: true, now: 10_000 })).toBe(true)
+
+    markChunkRecoveryAttempted({ storage, key, now: 10_000 })
+
+    expect(shouldAttemptChunkRecovery({ storage, key, online: true, now: 10_001 })).toBe(false)
+    expect(
+      shouldAttemptChunkRecovery({
+        storage,
+        key,
+        online: true,
+        now: 10_000 + chunkRecoveryAttemptMaxAgeMs + 1
+      })
+    ).toBe(true)
+  })
+
+  it('does not retry while the browser is offline', () => {
+    const storage = new MemoryStorage()
+    const key = buildChunkRecoveryStorageKey('https://r34.app/posts/rule34.xxx')
+
+    expect(shouldAttemptChunkRecovery({ storage, key, online: false })).toBe(false)
+  })
+})

--- a/test/assets/sentry-client-options.test.ts
+++ b/test/assets/sentry-client-options.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest'
-import { isSafariNativeTrackMenuError } from '../../sentry.client.options'
+import { describe, expect, it, vi } from 'vitest'
+import { isSafariNativeTrackMenuError, shouldDropRecoverableChunkLoadEvent } from '../../sentry.client.options'
 
 describe('Sentry client options', () => {
   it('identifies Safari native track menu errors', () => {
@@ -42,5 +42,47 @@ describe('Sentry client options', () => {
         }
       })
     ).toBe(false)
+  })
+
+  it('drops recoverable chunk load errors after the tab has already attempted chunk recovery', async () => {
+    const { chunkRecoveryStorageKeyPrefix } = await import('../../app/assets/js/chunk-error-recovery')
+    const originalWindow = globalThis.window
+    const originalSessionStorage = globalThis.sessionStorage
+    const recentRecoveryAttempt = Date.now()
+
+    vi.stubGlobal('window', { location: { href: 'https://r34.app/posts/rule34.xxx' } })
+    vi.stubGlobal('sessionStorage', {
+      getItem: (key: string) =>
+        key === `${chunkRecoveryStorageKeyPrefix}:https://r34.app/posts/rule34.xxx`
+          ? String(recentRecoveryAttempt)
+          : null
+    })
+
+    expect(
+      shouldDropRecoverableChunkLoadEvent({
+        exception: {
+          values: [
+            {
+              value: 'Importing a module script failed.'
+            }
+          ]
+        }
+      })
+    ).toBe(true)
+
+    expect(
+      shouldDropRecoverableChunkLoadEvent({
+        exception: {
+          values: [
+            {
+              value: 'Cannot read properties of null'
+            }
+          ]
+        }
+      })
+    ).toBe(false)
+
+    vi.stubGlobal('window', originalWindow)
+    vi.stubGlobal('sessionStorage', originalSessionStorage)
   })
 })


### PR DESCRIPTION
## Summary
- add manual Nuxt chunk-error recovery with one state-preserving reload per URL within a short retry window
- handle Vite's `vite:preloadError` event and prevent the rejected dynamic import from surfacing when recovery starts
- drop Sentry chunk-load events only after a recent recovery attempt, keeping unrecovered failures visible
- document the Vue template-ref lesson from this session in AGENTS.md

## Evidence
- Sentry still shows `R34-APP-Z` and `R34-APP-2` as high-volume production chunk-load issues; this recovery code is not on `origin/main` yet, so current production volume cannot validate it.
- Sampled Sentry chunk URLs returned `200` from production assets, so this is not only deleted-old-chunk behavior. Recovery still needs to cover blocked/interrupted dynamic imports.
- Nuxt documents hard reload as the default route chunk-load recovery and `experimental.emitRouteChunkError: 'manual'` for custom handling: https://nuxt.com/docs/4.x/getting-started/error-handling#errors-with-js-chunks
- Vite documents `vite:preloadError`, `event.preventDefault()`, and reload handling for failed dynamic imports: https://vite.dev/guide/build#load-error-handling

## Verification
- `rtk pnpm vitest run test/assets/chunk-error-recovery.test.ts test/assets/sentry-client-options.test.ts`
- `rtk pnpm typecheck`
- `rtk pnpm format:check`
- `rtk pnpm lint`
- `rtk pnpm build`

Note: the build initially failed in this fresh worktree because the shared-resources submodule was not initialized; after `git submodule update --init --recursive`, the build passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic recovery for chunk-load errors with intelligent retry throttling and online status checks.
  * Displays helpful error messages when app refresh is required.

* **Documentation**
  * Added Vue template refs conventions guidance for collecting DOM elements.

* **Tests**
  * Added comprehensive test suite for chunk-error recovery utilities and Sentry integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->