### PR TITLE
Filter recoverable chunk load errors

### DIFF
--- a/app/assets/js/chunk-load-errors.ts
+++ b/app/assets/js/chunk-load-errors.ts
@@ -1,0 +1,45 @@
+import type * as Sentry from '@sentry/nuxt'
+
+const chunkLoadMessagePatterns = [
+  /Importing a module script failed/i,
+  /Failed to fetch dynamically imported module/i,
+  /error loading dynamically imported module/i,
+  /Loading chunk \S+ failed/i,
+  /Loading CSS chunk \S+ failed/i,
+  /ChunkLoadError/i
+]
+
+export function getRecoverableChunkLoadMessage(error: unknown): string | null {
+  const message = getErrorMessage(error)
+
+  if (!message) {
+    return null
+  }
+
+  return chunkLoadMessagePatterns.some((pattern) => pattern.test(message)) ? message : null
+}
+
+export function getRecoverableChunkLoadMessageFromSentryEvent(event: Sentry.Event): string | null {
+  const exceptionValue = event.exception?.values?.find((value) => value.value)?.value
+  const message = exceptionValue ?? event.message
+
+  return getRecoverableChunkLoadMessage(message)
+}
+
+function getErrorMessage(error: unknown): string | null {
+  if (typeof error === 'string') {
+    return error
+  }
+
+  if (error instanceof Error) {
+    return error.message
+  }
+
+  if (typeof error === 'object' && error != null && 'message' in error) {
+    const message = (error as { message?: unknown }).message
+
+    return typeof message === 'string' ? message : null
+  }
+
+  return null
+}

--- a/sentry.client.options.ts
+++ b/sentry.client.options.ts
@@ -1,4 +1,5 @@
 import type * as Sentry from '@sentry/nuxt'
+import { getRecoverableChunkLoadMessageFromSentryEvent } from './app/assets/js/chunk-load-errors'
 import { project } from './config/project'
 
 type SentryNuxtInitOptions = Parameters<typeof import('@sentry/nuxt').init>[0]
@@ -49,6 +50,10 @@ export function buildSentryClientInitOptions(params: {
         return null
       }
 
+      if (isRecoverableChunkLoadError(event)) {
+        return null
+      }
+
       // The Nuxt Sentry SDK calls `beforeSend` for error events. The SDK typing
       // expects an ErrorEvent return type here, so we narrow accordingly.
       return event as Sentry.ErrorEvent
@@ -59,6 +64,10 @@ export function buildSentryClientInitOptions(params: {
   }
 
   return options
+}
+
+export function isRecoverableChunkLoadError(event: Sentry.Event): boolean {
+  return getRecoverableChunkLoadMessageFromSentryEvent(event) != null
 }
 
 const denyUrls: RegExp[] = [

--- a/test/assets/chunk-load-errors.test.ts
+++ b/test/assets/chunk-load-errors.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { getRecoverableChunkLoadMessage } from '../../app/assets/js/chunk-load-errors'
+
+describe('chunk load errors', () => {
+  it('recognizes recoverable dynamic import failures', () => {
+    expect(getRecoverableChunkLoadMessage(new TypeError('Importing a module script failed.'))).toBe(
+      'Importing a module script failed.'
+    )
+    expect(getRecoverableChunkLoadMessage(new Error('Failed to fetch dynamically imported module'))).toBe(
+      'Failed to fetch dynamically imported module'
+    )
+    expect(getRecoverableChunkLoadMessage(new Error('Cannot read properties of null'))).toBeNull()
+  })
+})

--- a/test/assets/sentry-client-options.test.ts
+++ b/test/assets/sentry-client-options.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { isSafariNativeTrackMenuError } from '../../sentry.client.options'
+import { isRecoverableChunkLoadError, isSafariNativeTrackMenuError } from '../../sentry.client.options'
 
 describe('Sentry client options', () => {
   it('identifies Safari native track menu errors', () => {
@@ -37,6 +37,32 @@ describe('Sentry client options', () => {
                   }
                 ]
               }
+            }
+          ]
+        }
+      })
+    ).toBe(false)
+  })
+
+  it('identifies recoverable chunk load errors', () => {
+    expect(
+      isRecoverableChunkLoadError({
+        exception: {
+          values: [
+            {
+              value: 'Importing a module script failed.'
+            }
+          ]
+        }
+      })
+    ).toBe(true)
+
+    expect(
+      isRecoverableChunkLoadError({
+        exception: {
+          values: [
+            {
+              value: 'Cannot read properties of null'
             }
           ]
         }


### PR DESCRIPTION
## Summary

- filter known browser dynamic-import/chunk-load failures from Sentry client events
- keep Nuxt's stock chunk recovery behavior instead of app-owned reload handling
- add focused tests for chunk-load message classification and Sentry filtering

## Evidence

Local production-build experiments showed stock Nuxt already recovers the tested chunk-failure cases:

- Route chunk failure during `/premium` -> `/premium/sign-in`: stock Nuxt reloaded once, landed on `/premium/sign-in`, and emitted no unhandled rejection.
- Non-route lazy chunk failure during sign-in toast loading: stock Nuxt recovered to a usable `/premium/sign-in` page; the interaction can be lost, but the app is not stuck.

The Sentry CLI token available in the repo returned `403` for issue reads, and browser access hit Sentry login, so I could not verify live replay/session recovery directly from Sentry in this environment.

## Verification

- `rtk pnpm vitest run test/assets/chunk-load-errors.test.ts test/assets/sentry-client-options.test.ts`
- `rtk pnpm lint`
- `rtk pnpm typecheck`
- `rtk pnpm format:check`
- `rtk pnpm build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced detection and handling of recoverable chunk-load errors, reducing noise in error tracking by suppressing false-positive reports.
* **Tests**
  * Added comprehensive test coverage for chunk-load error recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->