### PR TITLE
Add popunder evidence debug page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,9 @@ sw.*
 
 # Vim swap files
 *.swp
+
+# Local agent scratch
+.opencode/
+.docx/
+docs/
+token-usage-output.txt

--- a/app/assets/js/advertising/popunder-debug-report.ts
+++ b/app/assets/js/advertising/popunder-debug-report.ts
@@ -1,0 +1,92 @@
+import type { PopunderProviderMode } from '../../../composables/useAdvertisements'
+
+export type PopunderDebugEventType =
+  | 'armed'
+  | 'script-loaded'
+  | 'script-error'
+  | 'test-click'
+  | 'window-open'
+  | 'location-assign'
+  | 'location-replace'
+  | 'anchor-blank-click'
+  | 'visibilitychange'
+  | 'pagehide'
+  | 'beforeunload'
+  | 'instrumentation-failure'
+  | 'console-error'
+  | 'unhandledrejection'
+
+export type PopunderDebugEvent = {
+  type: PopunderDebugEventType
+  timestamp: string
+  elapsedMs: number
+  label?: string
+  url?: string
+  target?: string
+  visibilityState?: string
+  message?: string
+  stack?: string
+}
+
+export type PopunderDebugVerdict = {
+  allowedAttemptCount: number
+  duplicateAttemptCount: number
+  isAbusive: boolean
+}
+
+export type PopunderDebugReportInput = {
+  providerMode: PopunderProviderMode
+  providerLabel: string
+  scriptUrl: string
+  status: string
+  startedAt: string
+  currentUrl: string
+  referrer: string
+  clickCount: number
+  events: readonly PopunderDebugEvent[]
+}
+
+const defaultCooldownMs = 30 * 60 * 1000
+const candidateEventTypes = new Set<PopunderDebugEventType>([
+  'window-open',
+  'location-assign',
+  'location-replace',
+  'anchor-blank-click'
+])
+
+export function createPopunderDebugVerdict(events: readonly PopunderDebugEvent[], cooldownMs = defaultCooldownMs) {
+  const candidates = events
+    .filter((event) => candidateEventTypes.has(event.type))
+    .toSorted((left, right) => left.elapsedMs - right.elapsedMs)
+  const firstCandidate = candidates[0]
+
+  if (!firstCandidate) {
+    return {
+      allowedAttemptCount: 0,
+      duplicateAttemptCount: 0,
+      isAbusive: false
+    }
+  }
+
+  const duplicateAttemptCount = candidates.filter(
+    (event) => event !== firstCandidate && event.elapsedMs >= firstCandidate.elapsedMs && event.elapsedMs - firstCandidate.elapsedMs <= cooldownMs
+  ).length
+
+  return {
+    allowedAttemptCount: 1,
+    duplicateAttemptCount,
+    isAbusive: duplicateAttemptCount > 0
+  }
+}
+
+export function createPopunderDebugReport(input: PopunderDebugReportInput) {
+  return JSON.stringify(
+    {
+      ...input,
+      generatedAt: new Date().toISOString(),
+      verdict: createPopunderDebugVerdict(input.events)
+    },
+    null,
+    2
+  )
+}

--- a/app/composables/useAdvertisements.ts
+++ b/app/composables/useAdvertisements.ts
@@ -1,86 +1,117 @@
 import randomWeightedChoice from 'random-weighted-choice'
 
+/**
+ * Sum of all weights must be 1.0
+ */
+export const popunderProviders = [
+  /**
+   * ExoClick
+   * Pros:
+   * Cons:
+   */
+  // {
+  //   id: '',
+  //   weight: 1,
+  // },
+  /**
+   * Adsession
+   * Pros:
+   * Cons:
+   */
+  // {
+  //   id: '/js/popunder.js?v=7',
+  //   weight: 1,
+  // },
+  /**
+   * HilltopAds
+   * Pros: Good min payout (100) | Counts + impressions w/ same traffic? (could be abuse, use of multiple ads that we didnt agree)
+   * Cons: Not fixed CPM (~2.0) | Low Revenue (70)
+   */
+  {
+    key: 'hilltop',
+    label: 'HilltopAds',
+    id: 'https://yellowishgather.com/c.D/9v6/bW2/5aleSRW/Qj9SNojrA/zWMxTuk_zvNoiJ0S2kMgDBMux_OXTCMU3Z',
+    weight: 0.35
+  },
+  /**
+   * Clickadu
+   * Pros: Good CPM (2.1)
+   * Cons: Low revenue (50) | Does not count visits well | Clears console
+   */
+  {
+    key: 'clickadu',
+    label: 'Clickadu',
+    id: '/js/popunder2.js?v=10',
+    weight: 0.05
+  },
+  /**
+   * AdMaven
+   * Pros: Good CPM (3.5)
+   * Cons: Low Revenue (30) | Impression count lower than everybody else (less overall revenue) | Sometimes replaces current tab instead of opening in new tab | Possible malware: ads open requests to social media login
+   */
+  // {
+  //   id: 'https://dpjf9a2rbjbvp.cloudfront.net/?afjpd=1255038',
+  //   weight: 0.25
+  // },
+  /**
+   * AdsCarat
+   * Pros: Great CPM (2.5)
+   * Cons: Low Revenue (25) | Does not count visits well | Reloads website once?
+   */
+  // {
+  //   id: 'https://hp.scrannyplacebo.com/rMGqiS1acWcIq4LyI/oQRmJ',
+  //   weight: 1
+  // },
+  /**
+   * Profiton
+   * Pros: Good CPM (2.15) | Counts visits well
+   * Cons:
+   */
+  {
+    key: 'profiton',
+    label: 'Profiton',
+    id: 'https://je.deuxseethe.com/r1onMblLYR8e/rwnnn',
+    weight: 0.45
+  },
+  /**
+   * AdsTerra
+   * Pros:
+   * Cons:
+   */
+  {
+    key: 'adsterra',
+    label: 'AdsTerra',
+    id: 'https://laughedentrust.com/gOEgecu/kAi41dXqVy9f-/APTn2mopi0EK/ZYuxzOlInL9/23jslU_6yYUKuVVn_v9j/va82rI/dw-xJW2djcqgC5mfF7/4gbSUwOzf/rEAE3_4f5WEdqc3rM/VfHINUDVV3EC',
+    weight: 0.15
+  }
+] as const satisfies readonly { key: string; label: string; id: string; weight: number }[]
+
+export type PopunderProvider = (typeof popunderProviders)[number]
+export type PopunderProviderKey = PopunderProvider['key']
+
+export const popunderProviderKeys = popunderProviders.map(({ key }) => key)
+export const popunderProviderModes = ['random', ...popunderProviderKeys] as const
+export type PopunderProviderMode = (typeof popunderProviderModes)[number]
+
+export const popunderProviderChoices = popunderProviders.map(({ id, weight }) => ({ id, weight }))
+
+export function getPopunderProviderByKey(key: PopunderProviderKey): PopunderProvider {
+  return popunderProviders.find((provider) => provider.key === key) ?? popunderProviders[0]!
+}
+
+export function parsePopunderProviderMode(value: unknown): PopunderProviderMode {
+  return typeof value === 'string' && popunderProviderModes.includes(value as PopunderProviderMode)
+    ? (value as PopunderProviderMode)
+    : 'random'
+}
+
+export function selectRandomPopunderProviderScript() {
+  return randomWeightedChoice(popunderProviderChoices)
+}
+
 export default function () {
   const popunderScript = useState<string>('popunder-script', () => '')
   const pushScript = useState<string>('push-notification-script', () => '')
-
-  /**
-   * Sum of all weights must be 1.0
-   */
-  const popunderAds = [
-    /**
-     * ExoClick
-     * Pros:
-     * Cons:
-     */
-    // {
-    //   id: '',
-    //   weight: 1,
-    // },
-    /**
-     * Adsession
-     * Pros:
-     * Cons:
-     */
-    // {
-    //   id: '/js/popunder.js?v=7',
-    //   weight: 1,
-    // },
-    /**
-     * HilltopAds
-     * Pros: Good min payout (100) | Counts + impressions w/ same traffic? (could be abuse, use of multiple ads that we didnt agree)
-     * Cons: Not fixed CPM (~2.0) | Low Revenue (70)
-     */
-    {
-      id: 'https://yellowishgather.com/c.D/9v6/bW2/5aleSRW/Qj9SNojrA/zWMxTuk_zvNoiJ0S2kMgDBMux_OXTCMU3Z',
-      weight: 0.35
-    },
-    /**
-     * Clickadu
-     * Pros: Good CPM (2.1)
-     * Cons: Low revenue (50) | Does not count visits well | Clears console
-     */
-    {
-      id: '/js/popunder2.js?v=10',
-      weight: 0.05
-    },
-    /**
-     * AdMaven
-     * Pros: Good CPM (3.5)
-     * Cons: Low Revenue (30) | Impression count lower than everybody else (less overall revenue) | Sometimes replaces current tab instead of opening in new tab | Possible malware: ads open requests to social media login
-     */
-    // {
-    //   id: 'https://dpjf9a2rbjbvp.cloudfront.net/?afjpd=1255038',
-    //   weight: 0.25
-    // },
-    /**
-     * AdsCarat
-     * Pros: Great CPM (2.5)
-     * Cons: Low Revenue (25) | Does not count visits well | Reloads website once?
-     */
-    // {
-    //   id: 'https://hp.scrannyplacebo.com/rMGqiS1acWcIq4LyI/oQRmJ',
-    //   weight: 1
-    // },
-    /**
-     * Profiton
-     * Pros: Good CPM (2.15) | Counts visits well
-     * Cons:
-     */
-    {
-      id: 'https://je.deuxseethe.com/r1onMblLYR8e/rwnnn',
-      weight: 0.45
-    },
-    /**
-     * AdsTerra
-     * Pros:
-     * Cons:
-     */
-    {
-      id: 'https://laughedentrust.com/gOEgecu/kAi41dXqVy9f-/APTn2mopi0EK/ZYuxzOlInL9/23jslU_6yYUKuVVn_v9j/va82rI/dw-xJW2djcqgC5mfF7/4gbSUwOzf/rEAE3_4f5WEdqc3rM/VfHINUDVV3EC',
-      weight: 0.15
-    }
-  ]
 
   /**
    * Sum of all weights must be 1.0
@@ -153,8 +184,7 @@ export default function () {
 
   // Load popunder ad if not already loaded
   if (!popunderScript.value) {
-    const selectedPopunder = randomWeightedChoice(popunderAds)
-    popunderScript.value = selectedPopunder
+    popunderScript.value = selectRandomPopunderProviderScript()
   }
 
   // Load push notification ad if not already loaded

--- a/app/pages/__ad-debug/popunder.vue
+++ b/app/pages/__ad-debug/popunder.vue
@@ -1,0 +1,298 @@
+<script setup lang="ts">
+import {
+  getPopunderProviderByKey,
+  parsePopunderProviderMode,
+  popunderProviderModes,
+  popunderProviders,
+  selectRandomPopunderProviderScript,
+  type PopunderProviderKey
+} from '~/composables/useAdvertisements'
+import {
+  createPopunderDebugReport,
+  createPopunderDebugVerdict,
+  type PopunderDebugEvent,
+  type PopunderDebugEventType
+} from '~/assets/js/advertising/popunder-debug-report'
+
+useSeoMeta({
+  robots: 'noindex, nofollow',
+  title: 'Popunder local evidence debug'
+})
+
+const route = useRoute()
+const testTarget = useTemplateRef<HTMLButtonElement>('testTarget')
+
+const providerMode = computed(() => parsePopunderProviderMode(route.query.provider))
+const selectedRandomScript = ref('')
+const status = ref('idle')
+const armed = ref(false)
+const instrumentationInstalled = ref(false)
+const clientMounted = ref(false)
+const startedAt = ref('')
+const startedAtMs = ref(0)
+const armedProviderMode = ref(providerMode.value)
+const armedProviderLabel = ref('')
+const armedScriptUrl = ref('')
+const clickCount = ref(0)
+const events = ref<PopunderDebugEvent[]>([])
+const scriptedRunActive = ref(false)
+
+const selectedProvider = computed(() => {
+  if (providerMode.value !== 'random') {
+    return getPopunderProviderByKey(providerMode.value as PopunderProviderKey)
+  }
+
+  return popunderProviders.find((provider) => provider.id === selectedRandomScript.value) ?? getPopunderProviderByKey('hilltop')
+})
+const selectedProviderLabel = computed(() =>
+  providerMode.value === 'random' ? `Random (${selectedProvider.value.label})` : selectedProvider.value.label
+)
+const selectedScriptUrl = computed(() => (providerMode.value === 'random' ? selectedRandomScript.value : selectedProvider.value.id))
+const reportProviderMode = computed(() => (armed.value ? armedProviderMode.value : providerMode.value))
+const reportProviderLabel = computed(() => (armed.value ? armedProviderLabel.value : selectedProviderLabel.value))
+const reportScriptUrl = computed(() => (armed.value ? armedScriptUrl.value : selectedScriptUrl.value))
+const verdict = computed(() => createPopunderDebugVerdict(events.value))
+const reportJson = computed(() => {
+  if (!clientMounted.value) {
+    return ''
+  }
+
+  return createPopunderDebugReport({
+    providerMode: reportProviderMode.value,
+    providerLabel: reportProviderLabel.value,
+    scriptUrl: reportScriptUrl.value,
+    status: status.value,
+    startedAt: startedAt.value,
+    currentUrl: window.location.href,
+    referrer: document.referrer,
+    clickCount: clickCount.value,
+    events: events.value
+  })
+})
+
+onMounted(() => {
+  clientMounted.value = true
+})
+
+watch(
+  providerMode,
+  () => {
+    if (armed.value) {
+      return
+    }
+
+    selectedRandomScript.value = providerMode.value === 'random' ? selectRandomPopunderProviderScript() : ''
+    clearReport()
+  },
+  { immediate: true }
+)
+
+function elapsedMs() {
+  return startedAtMs.value ? Math.max(0, Math.round(performance.now() - startedAtMs.value)) : 0
+}
+
+function addEvent(type: PopunderDebugEventType, details: Partial<PopunderDebugEvent> = {}) {
+  events.value.push({
+    type,
+    timestamp: new Date().toISOString(),
+    elapsedMs: elapsedMs(),
+    ...details
+  })
+}
+
+function getStack() {
+  return new Error().stack?.split('\n').slice(2).join('\n')
+}
+
+function tryPatchLocationMethod(method: 'assign' | 'replace', eventType: 'location-assign' | 'location-replace') {
+  const original = window.location[method].bind(window.location)
+
+  try {
+    window.location[method] = ((url: string | URL) => {
+      addEvent(eventType, { url: String(url), stack: getStack() })
+      return original(url)
+    }) as Location[typeof method]
+  } catch (error) {
+    addEvent('instrumentation-failure', { message: `location.${method} instrumentation failed: ${String(error)}` })
+  }
+}
+
+function installInstrumentation() {
+  if (instrumentationInstalled.value) {
+    return
+  }
+
+  instrumentationInstalled.value = true
+
+  const originalOpen = window.open.bind(window)
+  window.open = ((url?: string | URL, target?: string, features?: string) => {
+    addEvent('window-open', { url: String(url ?? ''), target, message: features, stack: getStack() })
+    return originalOpen(url, target, features)
+  }) as typeof window.open
+
+  tryPatchLocationMethod('assign', 'location-assign')
+  tryPatchLocationMethod('replace', 'location-replace')
+
+  document.addEventListener(
+    'click',
+    (event) => {
+      const anchor = event.target instanceof Element ? event.target.closest('a[target="_blank"]') : null
+      if (anchor instanceof HTMLAnchorElement) {
+        addEvent('anchor-blank-click', { url: anchor.href, target: anchor.target, stack: getStack() })
+      }
+    },
+    true
+  )
+
+  document.addEventListener('visibilitychange', () => addEvent('visibilitychange', { visibilityState: document.visibilityState }))
+  window.addEventListener('pagehide', () => addEvent('pagehide'))
+  window.addEventListener('beforeunload', () => addEvent('beforeunload'))
+  window.addEventListener('error', (event) => addEvent('console-error', { message: event.message }))
+  window.addEventListener('unhandledrejection', (event) => addEvent('unhandledrejection', { message: String(event.reason) }))
+}
+
+function injectAdScript(scriptUrl: string) {
+  const script = document.createElement('script')
+  script.src = scriptUrl
+  script.defer = true
+  script.crossOrigin = 'anonymous'
+  script.onload = () => {
+    status.value = 'script-loaded'
+    addEvent('script-loaded', { url: scriptUrl })
+  }
+  script.onerror = () => {
+    status.value = 'script-error'
+    addEvent('script-error', { url: scriptUrl })
+  }
+  document.head.append(script)
+}
+
+function armAds() {
+  if (armed.value) {
+    return
+  }
+
+  armed.value = true
+  status.value = 'armed'
+  armedProviderMode.value = providerMode.value
+  armedProviderLabel.value = selectedProviderLabel.value
+  armedScriptUrl.value = selectedScriptUrl.value
+  startedAt.value = new Date().toISOString()
+  startedAtMs.value = performance.now()
+  installInstrumentation()
+  addEvent('armed', { label: armedProviderLabel.value, url: armedScriptUrl.value })
+  injectAdScript(armedScriptUrl.value)
+}
+
+function recordTestClick(label: string) {
+  clickCount.value += 1
+  addEvent('test-click', { label })
+}
+
+async function runScriptedClickTest() {
+  scriptedRunActive.value = true
+  for (let index = 1; index <= 10; index += 1) {
+    testTarget.value?.click()
+    await new Promise((resolve) => window.setTimeout(resolve, 750))
+  }
+  scriptedRunActive.value = false
+}
+
+async function copyReportJson() {
+  await navigator.clipboard.writeText(reportJson.value)
+  status.value = 'report-copied'
+}
+
+function clearReport() {
+  status.value = armed.value ? 'armed' : 'idle'
+  clickCount.value = 0
+  events.value = []
+}
+</script>
+
+<template>
+  <main class="mx-auto flex max-w-5xl flex-col gap-5 p-4 text-sm text-zinc-100 sm:p-6">
+    <header class="flex flex-col gap-2">
+      <h1 class="text-2xl font-semibold">Popunder local evidence debug</h1>
+      <p class="text-zinc-300">Local-only production debug page. Report stays in this browser until copied.</p>
+    </header>
+
+    <section class="rounded-lg border border-zinc-700 bg-zinc-900 p-4">
+      <h2 class="mb-3 text-lg font-semibold">Provider</h2>
+      <dl class="grid gap-2 break-all sm:grid-cols-[10rem_1fr]">
+        <dt class="text-zinc-400">Selected</dt>
+        <dd data-testid="selected-provider">{{ selectedProviderLabel }}</dd>
+        <dt class="text-zinc-400">Mode</dt>
+        <dd data-testid="selected-provider-mode">{{ providerMode }}</dd>
+        <dt class="text-zinc-400">Script URL</dt>
+        <dd data-testid="selected-script-url">{{ selectedScriptUrl }}</dd>
+        <dt class="text-zinc-400">Status</dt>
+        <dd data-testid="debug-status">{{ status }}</dd>
+      </dl>
+      <nav class="mt-4 flex flex-wrap gap-2">
+        <template v-if="armed">
+          <span
+            v-for="mode in popunderProviderModes"
+            :key="mode"
+            class="rounded border border-zinc-700 px-3 py-2 text-zinc-500"
+            :data-testid="`provider-link-${mode}`"
+          >
+            {{ mode }}
+          </span>
+        </template>
+        <template v-else>
+          <NuxtLink
+            v-for="mode in popunderProviderModes"
+            :key="mode"
+            :to="{ path: route.path, query: { provider: mode } }"
+            class="rounded border border-zinc-600 px-3 py-2 hover:bg-zinc-800"
+            :data-testid="`provider-link-${mode}`"
+          >
+            {{ mode }}
+          </NuxtLink>
+        </template>
+      </nav>
+    </section>
+
+    <section class="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+      <button
+        class="rounded bg-emerald-600 px-4 py-3 font-semibold text-white disabled:opacity-50"
+        :disabled="armed"
+        @click="armAds"
+      >
+        Arm ads
+      </button>
+      <button
+        ref="testTarget"
+        class="min-h-28 rounded bg-sky-600 px-4 py-3 font-semibold text-white disabled:opacity-50 sm:col-span-2 lg:col-span-2"
+        :disabled="!armed"
+        @click="recordTestClick('manual target click')"
+      >
+        Click test target
+      </button>
+      <button
+        class="rounded bg-violet-600 px-4 py-3 font-semibold text-white disabled:opacity-50"
+        :disabled="!armed || scriptedRunActive"
+        @click="runScriptedClickTest"
+      >
+        Run scripted click test
+      </button>
+      <div class="grid gap-3">
+        <button class="rounded bg-zinc-700 px-4 py-3 font-semibold text-white" @click="copyReportJson">
+          Copy report JSON
+        </button>
+        <button class="rounded bg-zinc-700 px-4 py-3 font-semibold text-white" @click="clearReport">Clear report</button>
+      </div>
+    </section>
+
+    <section class="rounded-lg border border-zinc-700 bg-zinc-900 p-4">
+      <h2 class="mb-3 text-lg font-semibold">Verdict</h2>
+      <pre data-testid="debug-verdict" class="overflow-auto whitespace-pre-wrap text-xs">{{ JSON.stringify(verdict, null, 2) }}</pre>
+    </section>
+
+    <section class="rounded-lg border border-zinc-700 bg-zinc-900 p-4">
+      <h2 class="mb-3 text-lg font-semibold">Report JSON</h2>
+      <pre data-testid="debug-report" class="max-h-[32rem] overflow-auto whitespace-pre-wrap text-xs">{{ reportJson }}</pre>
+    </section>
+  </main>
+</template>

--- a/app/pages/__ad-debug/popunder.vue
+++ b/app/pages/__ad-debug/popunder.vue
@@ -104,6 +104,16 @@ function getStack() {
   return new Error().stack?.split('\n').slice(2).join('\n')
 }
 
+let originalWindowOpen: typeof window.open | null = null
+let originalLocationAssign: Location['assign'] | null = null
+let originalLocationReplace: Location['replace'] | null = null
+const trackedListeners: { target: EventTarget; type: string; handler: EventListenerOrEventListenerObject; options?: boolean }[] = []
+
+function addTrackedListener(target: EventTarget, type: string, handler: EventListenerOrEventListenerObject, options?: boolean) {
+  target.addEventListener(type, handler, options)
+  trackedListeners.push({ target, type, handler, options })
+}
+
 function tryPatchLocationMethod(method: 'assign' | 'replace', eventType: 'location-assign' | 'location-replace') {
   const original = window.location[method].bind(window.location)
 
@@ -112,6 +122,12 @@ function tryPatchLocationMethod(method: 'assign' | 'replace', eventType: 'locati
       addEvent(eventType, { url: String(url), stack: getStack() })
       return original(url)
     }) as Location[typeof method]
+
+    if (method === 'assign') {
+      originalLocationAssign = original
+    } else {
+      originalLocationReplace = original
+    }
   } catch (error) {
     addEvent('instrumentation-failure', { message: `location.${method} instrumentation failed: ${String(error)}` })
   }
@@ -125,6 +141,7 @@ function installInstrumentation() {
   instrumentationInstalled.value = true
 
   const originalOpen = window.open.bind(window)
+  originalWindowOpen = originalOpen
   window.open = ((url?: string | URL, target?: string, features?: string) => {
     addEvent('window-open', { url: String(url ?? ''), target, message: features, stack: getStack() })
     return originalOpen(url, target, features)
@@ -133,7 +150,8 @@ function installInstrumentation() {
   tryPatchLocationMethod('assign', 'location-assign')
   tryPatchLocationMethod('replace', 'location-replace')
 
-  document.addEventListener(
+  addTrackedListener(
+    document,
     'click',
     (event) => {
       const anchor = event.target instanceof Element ? event.target.closest('a[target="_blank"]') : null
@@ -144,12 +162,39 @@ function installInstrumentation() {
     true
   )
 
-  document.addEventListener('visibilitychange', () => addEvent('visibilitychange', { visibilityState: document.visibilityState }))
-  window.addEventListener('pagehide', () => addEvent('pagehide'))
-  window.addEventListener('beforeunload', () => addEvent('beforeunload'))
-  window.addEventListener('error', (event) => addEvent('console-error', { message: event.message }))
-  window.addEventListener('unhandledrejection', (event) => addEvent('unhandledrejection', { message: String(event.reason) }))
+  addTrackedListener(document, 'visibilitychange', () => addEvent('visibilitychange', { visibilityState: document.visibilityState }))
+  addTrackedListener(window, 'pagehide', () => addEvent('pagehide'))
+  addTrackedListener(window, 'beforeunload', () => addEvent('beforeunload'))
+  addTrackedListener(window, 'error', (event) => addEvent('console-error', { message: (event as ErrorEvent).message }))
+  addTrackedListener(window, 'unhandledrejection', (event) =>
+    addEvent('unhandledrejection', { message: String((event as PromiseRejectionEvent).reason) })
+  )
 }
+
+function uninstallInstrumentation() {
+  if (!instrumentationInstalled.value) {
+    return
+  }
+
+  if (originalWindowOpen) {
+    window.open = originalWindowOpen
+  }
+  if (originalLocationAssign) {
+    window.location.assign = originalLocationAssign
+  }
+  if (originalLocationReplace) {
+    window.location.replace = originalLocationReplace
+  }
+
+  for (const { target, type, handler, options } of trackedListeners) {
+    target.removeEventListener(type, handler, options)
+  }
+  trackedListeners.length = 0
+
+  instrumentationInstalled.value = false
+}
+
+onUnmounted(uninstallInstrumentation)
 
 function injectAdScript(scriptUrl: string) {
   const script = document.createElement('script')

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -435,6 +435,8 @@ export default defineNuxtConfig({
 
     sources: ['/api/_sitemap-urls'],
 
+    exclude: ['/__ad-debug/**'],
+
     experimentalWarmUp: true,
 
     credits: false

--- a/test/assets/popunder-debug-report.test.ts
+++ b/test/assets/popunder-debug-report.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest'
+import { createPopunderDebugReport, createPopunderDebugVerdict } from '../../app/assets/js/advertising/popunder-debug-report'
+import { parsePopunderProviderMode } from '../../app/composables/useAdvertisements'
+
+describe('popunder provider mode parsing', () => {
+  it('accepts supported providers and falls back to random', () => {
+    expect(parsePopunderProviderMode('hilltop')).toBe('hilltop')
+    expect(parsePopunderProviderMode('clickadu')).toBe('clickadu')
+    expect(parsePopunderProviderMode('profiton')).toBe('profiton')
+    expect(parsePopunderProviderMode('adsterra')).toBe('adsterra')
+    expect(parsePopunderProviderMode('random')).toBe('random')
+    expect(parsePopunderProviderMode('unknown')).toBe('random')
+    expect(parsePopunderProviderMode(['hilltop'])).toBe('random')
+  })
+})
+
+describe('createPopunderDebugVerdict', () => {
+  it('returns clean verdict when no candidates exist', () => {
+    expect(createPopunderDebugVerdict([{ type: 'test-click', elapsedMs: 1000, timestamp: '2026-07-09T00:00:01.000Z' }])).toEqual({
+      allowedAttemptCount: 0,
+      duplicateAttemptCount: 0,
+      isAbusive: false
+    })
+  })
+
+  it('marks a second popunder candidate within 30 minutes as abusive', () => {
+    const verdict = createPopunderDebugVerdict([
+      { type: 'armed', elapsedMs: 0, timestamp: '2026-07-09T00:00:00.000Z' },
+      { type: 'window-open', elapsedMs: 1000, timestamp: '2026-07-09T00:00:01.000Z', target: '_blank' },
+      { type: 'location-assign', elapsedMs: 2000, timestamp: '2026-07-09T00:00:02.000Z', url: 'https://example.com' }
+    ])
+
+    expect(verdict).toEqual({
+      allowedAttemptCount: 1,
+      duplicateAttemptCount: 1,
+      isAbusive: true
+    })
+  })
+
+  it('counts candidates exactly 30 minutes after the first candidate as duplicates', () => {
+    expect(
+      createPopunderDebugVerdict([
+        { type: 'window-open', elapsedMs: 1000, timestamp: '2026-07-09T00:00:01.000Z' },
+        { type: 'location-replace', elapsedMs: 1000 + 30 * 60 * 1000, timestamp: '2026-07-09T00:30:01.000Z' }
+      ])
+    ).toEqual({
+      allowedAttemptCount: 1,
+      duplicateAttemptCount: 1,
+      isAbusive: true
+    })
+  })
+
+  it('ignores a second candidate after the cooldown window', () => {
+    const verdict = createPopunderDebugVerdict([
+      { type: 'window-open', elapsedMs: 1000, timestamp: '2026-07-09T00:00:01.000Z' },
+      { type: 'location-replace', elapsedMs: 1000 + 31 * 60 * 1000, timestamp: '2026-07-09T00:31:01.000Z' }
+    ])
+
+    expect(verdict).toEqual({
+      allowedAttemptCount: 1,
+      duplicateAttemptCount: 0,
+      isAbusive: false
+    })
+  })
+
+  it('sorts out-of-order candidates before applying the cooldown window', () => {
+    expect(
+      createPopunderDebugVerdict([
+        { type: 'location-replace', elapsedMs: 2000, timestamp: '2026-07-09T00:00:02.000Z' },
+        { type: 'window-open', elapsedMs: 1000, timestamp: '2026-07-09T00:00:01.000Z' }
+      ])
+    ).toEqual({
+      allowedAttemptCount: 1,
+      duplicateAttemptCount: 1,
+      isAbusive: true
+    })
+  })
+
+  it('counts every duplicate candidate inside the cooldown window', () => {
+    expect(
+      createPopunderDebugVerdict([
+        { type: 'window-open', elapsedMs: 1000, timestamp: '2026-07-09T00:00:01.000Z' },
+        { type: 'location-assign', elapsedMs: 2000, timestamp: '2026-07-09T00:00:02.000Z' },
+        { type: 'anchor-blank-click', elapsedMs: 3000, timestamp: '2026-07-09T00:00:03.000Z' }
+      ])
+    ).toEqual({
+      allowedAttemptCount: 1,
+      duplicateAttemptCount: 2,
+      isAbusive: true
+    })
+  })
+})
+
+describe('createPopunderDebugReport', () => {
+  it('returns formatted JSON with provider, script, and verdict metadata', () => {
+    const report = JSON.parse(
+      createPopunderDebugReport({
+        providerMode: 'hilltop',
+        providerLabel: 'HilltopAds',
+        scriptUrl: 'https://example.com/pop.js',
+        status: 'armed',
+        startedAt: '2026-07-09T00:00:00.000Z',
+        currentUrl: 'https://r34.app/__ad-debug/popunder?provider=hilltop',
+        referrer: '',
+        clickCount: 2,
+        events: [{ type: 'window-open', elapsedMs: 1000, timestamp: '2026-07-09T00:00:01.000Z' }]
+      })
+    )
+
+    expect(report.providerMode).toBe('hilltop')
+    expect(report.providerLabel).toBe('HilltopAds')
+    expect(report.scriptUrl).toBe('https://example.com/pop.js')
+    expect(report.verdict).toEqual({ allowedAttemptCount: 1, duplicateAttemptCount: 0, isAbusive: false })
+    expect(report.events).toHaveLength(1)
+  })
+})

--- a/test/server/sitemap.test.ts
+++ b/test/server/sitemap.test.ts
@@ -39,4 +39,10 @@ describe('Sitemap', async () => {
       )
     }
   })
+
+  it('excludes ad debug routes', async () => {
+    const locs = await getSitemapLocs('/sitemap.xml')
+
+    expect(locs.some((loc) => URL.parse(loc)?.pathname.startsWith('/__ad-debug/') ?? false)).toBe(false)
+  })
 })


### PR DESCRIPTION
## Summary
- add hidden local-only popunder debug page at /__ad-debug/popunder
- expose current popunder provider metadata for provider-specific testing
- add local report/verdict helpers and sitemap exclusion regression test
- ignore local agent scratch files

## Verification
- pnpm vitest run "test/assets/popunder-debug-report.test.ts" "test/server/sitemap.test.ts"
- pnpm lint
- pnpm typecheck
- pnpm build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a local-only popunder debug page with live instrumentation, event logging, computed evidence JSON, and copy-to-clipboard output.
  * Improved popunder ad provider selection with explicit provider modes and weighted random script picking.
* **Bug Fixes**
  * Debug reporting now flags repeated/suspicious open attempts using timing/cooldown logic.
  * Excluded the debug pages from sitemap generation.
* **Tests**
  * Added unit tests for provider mode parsing, debug verdict/report generation, and sitemap exclusions.
* **Chores**
  * Updated local scratch file ignore patterns in version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->