### PR TITLE
feat: add Kadam popunder trial

### DIFF
--- a/app/composables/useAdvertisements.ts
+++ b/app/composables/useAdvertisements.ts
@@ -91,7 +91,6 @@ export const popunderProviders = [
     key: 'kadam',
     label: 'Kadam',
     id: 'https://hdbtop.com/code/hneuyk427249',
-    targetClass: 'hneuyk427249',
     noCrossorigin: true,
     weight: 0.1
   }
@@ -99,7 +98,6 @@ export const popunderProviders = [
   key: string
   label: string
   id: string
-  targetClass?: string
   noCrossorigin?: true
   weight: number
 }[]
@@ -226,10 +224,6 @@ export function selectRandomPopunderProviderScript() {
   return randomWeightedChoice(popunderProviderChoices)
 }
 
-export function getPopunderProviderTargetClass(provider: PopunderProvider) {
-  return 'targetClass' in provider ? provider.targetClass : undefined
-}
-
 export function getPopunderProviderCrossorigin(provider: PopunderProvider) {
   return 'noCrossorigin' in provider ? undefined : ('anonymous' as const)
 }
@@ -256,9 +250,6 @@ export default function () {
 
   // Load selected ads
   useHead({
-    bodyAttrs: {
-      class: popunderProvider ? getPopunderProviderTargetClass(popunderProvider) : undefined
-    },
     script: [
       {
         src: popunderScript.value,

--- a/app/composables/useAdvertisements.ts
+++ b/app/composables/useAdvertisements.ts
@@ -71,7 +71,7 @@ export const popunderProviders = [
     key: 'profiton',
     label: 'Profiton',
     id: 'https://pb.burnetsasgmt.com/rjrr1lrmhPVU/140809',
-    weight: 0.25
+    weight: 0.15
   },
   /**
    * AdsTerra
@@ -83,8 +83,26 @@ export const popunderProviders = [
     label: 'AdsTerra',
     id: 'https://laughedentrust.com/gOEgecu/kAi41dXqVy9f-/APTn2mopi0EK/ZYuxzOlInL9/23jslU_6yYUKuVVn_v9j/va82rI/dw-xJW2djcqgC5mfF7/4gbSUwOzf/rEAE3_4f5WEdqc3rM/VfHINUDVV3EC',
     weight: 0.15
+  },
+  /**
+   * Kadam
+   */
+  {
+    key: 'kadam',
+    label: 'Kadam',
+    id: 'https://hdbtop.com/code/hneuyk427249',
+    containerClass: 'hneuyk427249',
+    noCrossorigin: true,
+    weight: 0.1
   }
-] as const satisfies readonly { key: string; label: string; id: string; weight: number }[]
+] as const satisfies readonly {
+  key: string
+  label: string
+  id: string
+  containerClass?: string
+  noCrossorigin?: true
+  weight: number
+}[]
 
 export type PopunderProvider = (typeof popunderProviders)[number]
 export type PopunderProviderKey = PopunderProvider['key']
@@ -208,6 +226,16 @@ export function selectRandomPopunderProviderScript() {
   return randomWeightedChoice(popunderProviderChoices)
 }
 
+export function ensurePopunderProviderContainer(provider: PopunderProvider) {
+  if (!('containerClass' in provider) || document.querySelector(`.${provider.containerClass}`)) {
+    return
+  }
+
+  const container = document.createElement('div')
+  container.className = provider.containerClass
+  document.body.append(container)
+}
+
 export function selectRandomPushAdProviderScript() {
   return randomWeightedChoice(pushAdProviderChoices)
 }
@@ -226,6 +254,13 @@ export default function () {
     pushScript.value = selectRandomPushAdProviderScript()
   }
 
+  const popunderProvider = popunderProviders.find(({ id }) => id === popunderScript.value)
+  if (import.meta.client && popunderProvider) {
+    ensurePopunderProviderContainer(popunderProvider)
+  }
+  const popunderCrossorigin =
+    popunderProvider && 'noCrossorigin' in popunderProvider ? undefined : ('anonymous' as const)
+
   // Load selected ads
   useHead({
     script: [
@@ -235,7 +270,7 @@ export default function () {
         defer: true,
 
         // Fix for CORS issues - https://unhead.unjs.io/usage/composables/use-script#referrerpolicy-and-crossorigin
-        crossorigin: 'anonymous'
+        crossorigin: popunderCrossorigin
       },
       {
         src: pushScript.value,

--- a/app/composables/useAdvertisements.ts
+++ b/app/composables/useAdvertisements.ts
@@ -91,7 +91,7 @@ export const popunderProviders = [
     key: 'kadam',
     label: 'Kadam',
     id: 'https://hdbtop.com/code/hneuyk427249',
-    containerClass: 'hneuyk427249',
+    targetClass: 'hneuyk427249',
     noCrossorigin: true,
     weight: 0.1
   }
@@ -99,7 +99,7 @@ export const popunderProviders = [
   key: string
   label: string
   id: string
-  containerClass?: string
+  targetClass?: string
   noCrossorigin?: true
   weight: number
 }[]
@@ -226,14 +226,12 @@ export function selectRandomPopunderProviderScript() {
   return randomWeightedChoice(popunderProviderChoices)
 }
 
-export function ensurePopunderProviderContainer(provider: PopunderProvider) {
-  if (!('containerClass' in provider) || document.querySelector(`.${provider.containerClass}`)) {
-    return
-  }
+export function getPopunderProviderTargetClass(provider: PopunderProvider) {
+  return 'targetClass' in provider ? provider.targetClass : undefined
+}
 
-  const container = document.createElement('div')
-  container.className = provider.containerClass
-  document.body.append(container)
+export function getPopunderProviderCrossorigin(provider: PopunderProvider) {
+  return 'noCrossorigin' in provider ? undefined : ('anonymous' as const)
 }
 
 export function selectRandomPushAdProviderScript() {
@@ -255,14 +253,12 @@ export default function () {
   }
 
   const popunderProvider = popunderProviders.find(({ id }) => id === popunderScript.value)
-  if (import.meta.client && popunderProvider) {
-    ensurePopunderProviderContainer(popunderProvider)
-  }
-  const popunderCrossorigin =
-    popunderProvider && 'noCrossorigin' in popunderProvider ? undefined : ('anonymous' as const)
 
   // Load selected ads
   useHead({
+    bodyAttrs: {
+      class: popunderProvider ? getPopunderProviderTargetClass(popunderProvider) : undefined
+    },
     script: [
       {
         src: popunderScript.value,
@@ -270,7 +266,7 @@ export default function () {
         defer: true,
 
         // Fix for CORS issues - https://unhead.unjs.io/usage/composables/use-script#referrerpolicy-and-crossorigin
-        crossorigin: popunderCrossorigin
+        crossorigin: popunderProvider ? getPopunderProviderCrossorigin(popunderProvider) : 'anonymous'
       },
       {
         src: pushScript.value,

--- a/app/pages/__ad-debug/popunder.vue
+++ b/app/pages/__ad-debug/popunder.vue
@@ -2,7 +2,6 @@
   import {
     getPopunderProviderByKey,
     getPopunderProviderCrossorigin,
-    getPopunderProviderTargetClass,
     parsePopunderProviderMode,
     popunderProviderModes,
     popunderProviders,
@@ -79,9 +78,6 @@
   })
 
   useHead(() => ({
-    bodyAttrs: {
-      class: armedProvider.value ? getPopunderProviderTargetClass(armedProvider.value) : undefined
-    },
     script: armedProvider.value
       ? [
           {

--- a/app/pages/__ad-debug/popunder.vue
+++ b/app/pages/__ad-debug/popunder.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
   import {
-    ensurePopunderProviderContainer,
     getPopunderProviderByKey,
+    getPopunderProviderCrossorigin,
+    getPopunderProviderTargetClass,
     parsePopunderProviderMode,
     popunderProviderModes,
     popunderProviders,
     selectRandomPopunderProviderScript,
-    type PopunderProvider,
     type PopunderProviderKey
   } from '~/composables/useAdvertisements'
   import {
@@ -53,6 +53,9 @@
   const selectedScriptUrl = computed(() =>
     providerMode.value === 'random' ? selectedRandomScript.value : selectedProvider.value.id
   )
+  const armedProvider = computed(() =>
+    armed.value ? popunderProviders.find(({ id }) => id === armedScriptUrl.value) : undefined
+  )
   const reportProviderMode = computed(() => (armed.value ? armedProviderMode.value : providerMode.value))
   const reportProviderLabel = computed(() => (armed.value ? armedProviderLabel.value : selectedProviderLabel.value))
   const reportScriptUrl = computed(() => (armed.value ? armedScriptUrl.value : selectedScriptUrl.value))
@@ -74,6 +77,29 @@
       events: events.value
     })
   })
+
+  useHead(() => ({
+    bodyAttrs: {
+      class: armedProvider.value ? getPopunderProviderTargetClass(armedProvider.value) : undefined
+    },
+    script: armedProvider.value
+      ? [
+          {
+            src: armedProvider.value.id,
+            defer: true,
+            crossorigin: getPopunderProviderCrossorigin(armedProvider.value),
+            onload: () => {
+              status.value = 'script-loaded'
+              addEvent('script-loaded', { url: armedProvider.value?.id })
+            },
+            onerror: () => {
+              status.value = 'script-error'
+              addEvent('script-error', { url: armedProvider.value?.id })
+            }
+          }
+        ]
+      : []
+  }))
 
   onMounted(() => {
     clientMounted.value = true
@@ -178,24 +204,6 @@
 
   onUnmounted(uninstallInstrumentation)
 
-  function injectAdScript(provider: PopunderProvider) {
-    const script = document.createElement('script')
-    script.src = provider.id
-    script.defer = true
-    if (!('noCrossorigin' in provider)) {
-      script.crossOrigin = 'anonymous'
-    }
-    script.onload = () => {
-      status.value = 'script-loaded'
-      addEvent('script-loaded', { url: provider.id })
-    }
-    script.onerror = () => {
-      status.value = 'script-error'
-      addEvent('script-error', { url: provider.id })
-    }
-    document.head.append(script)
-  }
-
   function armAds() {
     if (armed.value) {
       return
@@ -210,8 +218,6 @@
     startedAtMs.value = performance.now()
     installInstrumentation()
     addEvent('armed', { label: armedProviderLabel.value, url: armedScriptUrl.value })
-    ensurePopunderProviderContainer(selectedProvider.value)
-    injectAdScript(selectedProvider.value)
   }
 
   function recordTestClick(label: string) {

--- a/app/pages/__ad-debug/popunder.vue
+++ b/app/pages/__ad-debug/popunder.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
   import {
+    ensurePopunderProviderContainer,
     getPopunderProviderByKey,
     parsePopunderProviderMode,
     popunderProviderModes,
     popunderProviders,
     selectRandomPopunderProviderScript,
+    type PopunderProvider,
     type PopunderProviderKey
   } from '~/composables/useAdvertisements'
   import {
@@ -176,18 +178,20 @@
 
   onUnmounted(uninstallInstrumentation)
 
-  function injectAdScript(scriptUrl: string) {
+  function injectAdScript(provider: PopunderProvider) {
     const script = document.createElement('script')
-    script.src = scriptUrl
+    script.src = provider.id
     script.defer = true
-    script.crossOrigin = 'anonymous'
+    if (!('noCrossorigin' in provider)) {
+      script.crossOrigin = 'anonymous'
+    }
     script.onload = () => {
       status.value = 'script-loaded'
-      addEvent('script-loaded', { url: scriptUrl })
+      addEvent('script-loaded', { url: provider.id })
     }
     script.onerror = () => {
       status.value = 'script-error'
-      addEvent('script-error', { url: scriptUrl })
+      addEvent('script-error', { url: provider.id })
     }
     document.head.append(script)
   }
@@ -206,7 +210,8 @@
     startedAtMs.value = performance.now()
     installInstrumentation()
     addEvent('armed', { label: armedProviderLabel.value, url: armedScriptUrl.value })
-    injectAdScript(armedScriptUrl.value)
+    ensurePopunderProviderContainer(selectedProvider.value)
+    injectAdScript(selectedProvider.value)
   }
 
   function recordTestClick(label: string) {

--- a/test/assets/popunder-provider-weights.test.ts
+++ b/test/assets/popunder-provider-weights.test.ts
@@ -13,6 +13,7 @@ describe('popunder provider weights', () => {
       noCrossorigin: true,
       weight: 0.1
     })
+    expect(popunderProviders.find(({ key }) => key === 'profiton')).toMatchObject({ weight: 0.15 })
   })
 })
 

--- a/test/assets/popunder-provider-weights.test.ts
+++ b/test/assets/popunder-provider-weights.test.ts
@@ -7,9 +7,8 @@ describe('popunder provider weights', () => {
     expect(total).toBeCloseTo(1, 5)
   })
 
-  it('includes the Kadam trial and its required target class', () => {
+  it('includes the Kadam trial', () => {
     expect(popunderProviders.find(({ key }) => key === 'kadam')).toMatchObject({
-      targetClass: 'hneuyk427249',
       noCrossorigin: true,
       weight: 0.1
     })

--- a/test/assets/popunder-provider-weights.test.ts
+++ b/test/assets/popunder-provider-weights.test.ts
@@ -6,6 +6,14 @@ describe('popunder provider weights', () => {
     const total = popunderProviders.reduce((sum, provider) => sum + provider.weight, 0)
     expect(total).toBeCloseTo(1, 5)
   })
+
+  it('includes the Kadam trial and its required container', () => {
+    expect(popunderProviders.find(({ key }) => key === 'kadam')).toMatchObject({
+      containerClass: 'hneuyk427249',
+      noCrossorigin: true,
+      weight: 0.1
+    })
+  })
 })
 
 describe('push ad provider weights', () => {

--- a/test/assets/popunder-provider-weights.test.ts
+++ b/test/assets/popunder-provider-weights.test.ts
@@ -7,9 +7,9 @@ describe('popunder provider weights', () => {
     expect(total).toBeCloseTo(1, 5)
   })
 
-  it('includes the Kadam trial and its required container', () => {
+  it('includes the Kadam trial and its required target class', () => {
     expect(popunderProviders.find(({ key }) => key === 'kadam')).toMatchObject({
-      containerClass: 'hneuyk427249',
+      targetClass: 'hneuyk427249',
       noCrossorigin: true,
       weight: 0.1
     })

--- a/test/pages/popunder-debug.test.ts
+++ b/test/pages/popunder-debug.test.ts
@@ -1,9 +1,15 @@
 import { readFileSync } from 'node:fs'
+import { setup, url } from '@nuxt/test-utils'
 import { describe, expect, it } from 'vitest'
+import { defaultSetupConfig, useTrackedPageFactory } from '../helper'
 
 const page = readFileSync(new URL('../../app/pages/__ad-debug/popunder.vue', import.meta.url), 'utf8')
 
-describe('popunder debug page', () => {
+describe('popunder debug page', async () => {
+  await setup(defaultSetupConfig)
+
+  const createTrackedPage = useTrackedPageFactory()
+
   it('uses passive instrumentation and a same-origin post link', () => {
     expect(page).not.toMatch(/window\.open\s*=/)
     expect(page).not.toMatch(/window\.location\.(assign|replace)\s*=/)
@@ -13,5 +19,24 @@ describe('popunder debug page', () => {
     expect(page).toContain('ensurePopunderProviderContainer(selectedProvider.value)')
     expect(page).toContain('data-testid="click-test-target"')
     expect(page).toContain('href="/posts/rule34.xxx?tags=rating%3Asafe"')
+  })
+
+  it('injects Kadam with its required container and no crossorigin attribute', async () => {
+    const browserPage = await createTrackedPage()
+    await browserPage.route('https://hdbtop.com/code/hneuyk427249', (route) =>
+      route.fulfill({ contentType: 'application/javascript', body: '' })
+    )
+    await browserPage.goto(url('/__ad-debug/popunder?provider=kadam'))
+    await browserPage.waitForFunction(
+      () => document.querySelector('[data-testid="debug-report"]')?.textContent?.trim().length
+    )
+
+    expect(await browserPage.getByTestId('selected-provider').textContent()).toBe('Kadam')
+    await browserPage.getByRole('button', { name: 'Arm ads' }).click()
+
+    expect(await browserPage.locator('.hneuyk427249').count()).toBe(1)
+    const script = browserPage.locator('script[src="https://hdbtop.com/code/hneuyk427249"]')
+    expect(await script.count()).toBe(1)
+    expect(await script.getAttribute('crossorigin')).toBeNull()
   })
 })

--- a/test/pages/popunder-debug.test.ts
+++ b/test/pages/popunder-debug.test.ts
@@ -16,17 +16,16 @@ describe('popunder debug page', async () => {
     expect(page).toContain('data-testid="reset-test-storage"')
     expect(page).toContain('localStorage.clear()')
     expect(page).toContain('sessionStorage.clear()')
-    expect(page).toContain('getPopunderProviderTargetClass(armedProvider.value)')
     expect(page).toContain('data-testid="click-test-target"')
     expect(page).toContain('href="/posts/rule34.xxx?tags=rating%3Asafe"')
   })
 
-  it('injects Kadam after applying its target class and without crossorigin', async () => {
+  it('injects Kadam without crossorigin', async () => {
     const browserPage = await createTrackedPage()
     await browserPage.route('https://hdbtop.com/code/hneuyk427249', (route) =>
       route.fulfill({
         contentType: 'application/javascript',
-        body: `window.__kadamTarget = document.querySelector('.hneuyk427249')?.tagName`
+        body: `window.__kadamLoaded = true`
       })
     )
     await browserPage.goto(url('/__ad-debug/popunder?provider=kadam'))
@@ -35,12 +34,11 @@ describe('popunder debug page', async () => {
     )
 
     expect(await browserPage.getByTestId('selected-provider').textContent()).toBe('Kadam')
-    expect(await browserPage.locator('body.hneuyk427249').count()).toBe(0)
     await browserPage.getByRole('button', { name: 'Arm ads' }).click()
 
     await expect
-      .poll(() => browserPage.evaluate(() => (window as Window & { __kadamTarget?: string }).__kadamTarget))
-      .toBe('BODY')
+      .poll(() => browserPage.evaluate(() => (window as Window & { __kadamLoaded?: boolean }).__kadamLoaded))
+      .toBe(true)
     const script = browserPage.locator('script[src="https://hdbtop.com/code/hneuyk427249"]')
     expect(await script.count()).toBe(1)
     expect(await script.getAttribute('crossorigin')).toBeNull()

--- a/test/pages/popunder-debug.test.ts
+++ b/test/pages/popunder-debug.test.ts
@@ -10,6 +10,7 @@ describe('popunder debug page', () => {
     expect(page).toContain('data-testid="reset-test-storage"')
     expect(page).toContain('localStorage.clear()')
     expect(page).toContain('sessionStorage.clear()')
+    expect(page).toContain('ensurePopunderProviderContainer(selectedProvider.value)')
     expect(page).toContain('data-testid="click-test-target"')
     expect(page).toContain('href="/posts/rule34.xxx?tags=rating%3Asafe"')
   })

--- a/test/pages/popunder-debug.test.ts
+++ b/test/pages/popunder-debug.test.ts
@@ -16,15 +16,18 @@ describe('popunder debug page', async () => {
     expect(page).toContain('data-testid="reset-test-storage"')
     expect(page).toContain('localStorage.clear()')
     expect(page).toContain('sessionStorage.clear()')
-    expect(page).toContain('ensurePopunderProviderContainer(selectedProvider.value)')
+    expect(page).toContain('getPopunderProviderTargetClass(armedProvider.value)')
     expect(page).toContain('data-testid="click-test-target"')
     expect(page).toContain('href="/posts/rule34.xxx?tags=rating%3Asafe"')
   })
 
-  it('injects Kadam with its required container and no crossorigin attribute', async () => {
+  it('injects Kadam after applying its target class and without crossorigin', async () => {
     const browserPage = await createTrackedPage()
     await browserPage.route('https://hdbtop.com/code/hneuyk427249', (route) =>
-      route.fulfill({ contentType: 'application/javascript', body: '' })
+      route.fulfill({
+        contentType: 'application/javascript',
+        body: `window.__kadamTarget = document.querySelector('.hneuyk427249')?.tagName`
+      })
     )
     await browserPage.goto(url('/__ad-debug/popunder?provider=kadam'))
     await browserPage.waitForFunction(
@@ -32,9 +35,12 @@ describe('popunder debug page', async () => {
     )
 
     expect(await browserPage.getByTestId('selected-provider').textContent()).toBe('Kadam')
+    expect(await browserPage.locator('body.hneuyk427249').count()).toBe(0)
     await browserPage.getByRole('button', { name: 'Arm ads' }).click()
 
-    expect(await browserPage.locator('.hneuyk427249').count()).toBe(1)
+    await expect
+      .poll(() => browserPage.evaluate(() => (window as Window & { __kadamTarget?: string }).__kadamTarget))
+      .toBe('BODY')
     const script = browserPage.locator('script[src="https://hdbtop.com/code/hneuyk427249"]')
     expect(await script.count()).toBe(1)
     expect(await script.getAttribute('crossorigin')).toBeNull()


### PR DESCRIPTION
## Summary
- add Kadam as a 10% popunder trial and reduce ProfitOn from 25% to 15%
- support provider-specific omission of `crossorigin` through the existing Nuxt/Unhead loader
- load Kadam directly with no provider container, target class, or extra DOM markup
- include Kadam in the existing passive debug harness and provider-weight coverage

## Verification
- real Kadam tag loaded in the dedicated no-ad-block Testing Chrome profile with zero `.hneuyk427249` elements
- real provider configuration reports `nthClick: 1` and `next: 1200`
- first genuine click opened exactly one external ad tab; the original debug page survived
- after 12 seconds, the second genuine click opened no ad and followed the expected same-origin R34 link
- no duplicate delivery or destructive source-tab replacement occurred
- one auxiliary identity-sync request reported `ERR_BLOCKED_BY_CLIENT`, but the tag, bid request, and accepted delivery completed successfully
- browser regression verifies Kadam loads without a `crossorigin` attribute
- focused Vitest: 5 tests passed
- Prettier, ESLint, Nuxt typecheck, production build, and git diff check passed

## Scope
No provider settings, browser blocker settings, code outside this PR, or deployment state were changed during verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Kadam as a supported popunder advertising provider.
  - Added provider-specific script loading behavior for improved compatibility.
  - Enhanced the popunder debugging page to track script loading and errors.

- **Bug Fixes**
  - Adjusted provider selection weights, including a reduced weighting for Profiton.

- **Tests**
  - Added coverage verifying provider weights and Kadam’s script configuration.
  - Added end-to-end validation of Kadam script loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->